### PR TITLE
harness: drop hidden ORDER BY sort keys in the reference evaluator's Sort

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -910,7 +910,20 @@ bool eval_node(const LogicalNode* n, EvalCtx& ctx, Table& out) {
             if (!eval_node(n->child(0), ctx, child)) return false;
             std::stable_sort(child.begin(), child.end(),
                              [&](const Row& a, const Row& b) { return sort_less(a, b, n, ctx); });
-            out = std::move(child);
+            // The binder may append HIDDEN ORDER BY sort keys as trailing columns
+            // of the child (so the Sort can order by a non-selected column). The
+            // Sort node's own output schema is narrower in that case. Project each
+            // row down to the declared output width, dropping any trailing hidden
+            // key columns. Guard: only ever drop, never pad — if the child is
+            // already at (or below) the declared width this is a no-op.
+            // M13: skip the truncation, leaking trailing hidden sort keys into
+            // the result (the pre-fix bug) so the width-preservation test is
+            // falsifiable.
+            const std::size_t w = n->output.size();
+            for (Row& r : child) {
+                if (g_mutant != 13 && r.size() > w) r.resize(w);
+                out.push_back(std::move(r));
+            }
             return true;
         }
         case LogicalOp::Limit: {
@@ -1109,6 +1122,7 @@ const MutantInfo kMutants[] = {
     {10, "M10 CASE eval ignores every WHEN (falls through to ELSE)"},
     {11, "M11 membership in an empty set is UNKNOWN, not FALSE"},
     {12, "M12 second optimize() pass changes the plan (non-idempotent)"},
+    {13, "M13 Sort eval leaks hidden ORDER BY sort keys (no truncation to output width)"},
 };
 }  // namespace
 

--- a/tests/smoke/smoke_tests.cpp
+++ b/tests/smoke/smoke_tests.cpp
@@ -132,6 +132,26 @@ static void register_smoke_tests() {
                       "SELECT id FROM users WHERE age > 25",
                       "(1=1) AND p == p after folding");
     });
+
+    // ---- ORDER BY on a NON-selected column: the binder appends the sort key as
+    //   a hidden trailing column of the Project so Sort can order by it; the Sort
+    //   node's output schema is narrower, and the evaluator must project the
+    //   hidden key back out. `SELECT id FROM users ORDER BY age` must therefore
+    //   yield exactly one column (id), identical to the same query without the
+    //   sort. Killed by M13 (Sort eval leaks the hidden key -> width 2, and the
+    //   bag no longer matches the id-only set).
+    test("smoke.order_by_hidden_key_not_leaked", [] {
+        auto s = oracle("SELECT id FROM users ORDER BY age");
+        auto ro = eval(s.optimized, data());
+        check(ro.has_value(), "ORDER-BY-hidden-key eval supported");
+        if (ro && !ro->empty()) {
+            check(ro->front().size() == 1,
+                  "ORDER BY a non-selected column outputs one column (hidden key dropped)");
+        }
+        expect_bag_eq("SELECT id FROM users ORDER BY age",
+                      "SELECT id FROM users",
+                      "ORDER BY a hidden column does not change the projected column set");
+    });
 }
 
 static bool _smoke_registered = (register_smoke_tests(), true);


### PR DESCRIPTION
## Problem

When `ORDER BY` sorts by a **non-selected** column, the binder appends that sort key as a hidden trailing column of the child `Project` so the `Sort` can reference it; the `Sort` node's own output schema is correspondingly narrower. The reference evaluator's `Sort` case returned the sorted child rows verbatim, **leaking the hidden key** into the result:

```
SELECT id FROM users ORDER BY age   →   evaluated to (id, age), should be (id)
```

The DB25 **plan is correct** — this was an evaluator-fidelity gap that surfaced only against external engines. A cross-engine differential (DB25's evaluator vs SQLite/DuckDB/Polars on identical data) flagged the extra column.

## Fix

Project each sorted row down to the `Sort` node's declared output width, dropping trailing hidden keys. The guard only ever drops, never pads — a no-op when there is no hidden key. Both the bound and optimized plans are truncated equally, so the internal bound-vs-optimized differential is preserved.

## Falsifiability

Per the gate's contract (every test must be killed by ≥1 mutant):
- **Mutant M13** — `Sort` eval leaks the hidden key (reintroduces the bug).
- Smoke test `smoke.order_by_hidden_key_not_leaked` — asserts the one-column width and the id-only bag; killed by M13.

**Gate: 81 tests, 13 mutants, all falsifiable, GATE PASSED.** The cross-engine differential improves from 37/40 to **39/40** DB25==SQLite (the remaining case is a NULL sort-ordering *convention*, deliberately left untouched).