### PR TITLE
harness: make ORDER BY ordering falsifiable (seq_equal + M14 + sequence test)

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -33,6 +33,12 @@
 //   M12 a second optimize() pass changes the plan - a dropped predicate makes
 //       optimize(optimize(p)) differ from optimize(p) (injected in the property
 //       suite's idempotence check). Caught by the optimizer-idempotence property.
+//   M13 Sort eval leaks hidden ORDER BY sort keys (skips the truncation to the
+//       output width). Caught by the ORDER-BY-hidden-key width test.
+//   M14 Sort eval reverses the row order (models a dropped/reversed ORDER BY
+//       direction). Invisible to every bag_equal (multiset) check; caught ONLY
+//       by the order-sensitive ORDER BY sequence test (seq_equal vs a literal
+//       ordered oracle).
 //
 // A test is FALSIFIABLE iff some mutant makes it fail. The gate reports any test
 // that survives every mutant as NON-FALSIFIABLE (vacuous) and exits non-zero.
@@ -910,6 +916,11 @@ bool eval_node(const LogicalNode* n, EvalCtx& ctx, Table& out) {
             if (!eval_node(n->child(0), ctx, child)) return false;
             std::stable_sort(child.begin(), child.end(),
                              [&](const Row& a, const Row& b) { return sort_less(a, b, n, ctx); });
+            // M14: reverse the sorted order, modelling a Sort that produces the
+            // wrong row order (a dropped or reversed ORDER BY direction). Caught
+            // ONLY by the order-sensitive ORDER BY tests (seq_equal against a
+            // literal ordered oracle); a bag_equal / multiset check cannot see it.
+            if (g_mutant == 14) std::reverse(child.begin(), child.end());
             // The binder may append HIDDEN ORDER BY sort keys as trailing columns
             // of the child (so the Sort can order by a non-selected column). The
             // Sort node's own output schema is narrower in that case. Project each
@@ -984,6 +995,21 @@ bool bag_equal(const Table& a, const Table& b) {
             if (same) { used[j] = true; matched = true; break; }
         }
         if (!matched) return false;
+    }
+    return true;
+}
+
+// ===========================================================================
+// seq_equal (sequence equality, order-SENSITIVE, NULL-aware). Rows must match
+// position-by-position - the only way to detect a dropped/reversed Sort, which
+// bag_equal (multiset) is blind to.
+// ===========================================================================
+bool seq_equal(const Table& a, const Table& b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i].size() != b[i].size()) return false;
+        for (std::size_t j = 0; j < a[i].size(); ++j)
+            if (!value_identical(a[i][j], b[i][j])) return false;
     }
     return true;
 }
@@ -1123,6 +1149,7 @@ const MutantInfo kMutants[] = {
     {11, "M11 membership in an empty set is UNKNOWN, not FALSE"},
     {12, "M12 second optimize() pass changes the plan (non-idempotent)"},
     {13, "M13 Sort eval leaks hidden ORDER BY sort keys (no truncation to output width)"},
+    {14, "M14 Sort eval reverses the row order (wrong ORDER BY direction)"},
 };
 }  // namespace
 

--- a/harness/harness.hpp
+++ b/harness/harness.hpp
@@ -98,6 +98,10 @@ struct Stages {
 // Multiset (order-independent) equality with NULL-aware element comparison.
 [[nodiscard]] bool bag_equal(const Table& a, const Table& b);
 
+// Sequence (order-SENSITIVE) equality: rows must match position-by-position.
+// Use for ORDER BY tests - bag_equal cannot detect a dropped/reversed Sort.
+[[nodiscard]] bool seq_equal(const Table& a, const Table& b);
+
 // ---------------------------------------------------------------------------
 // Structural plan predicates (for tests that assert an optimization happened).
 // ---------------------------------------------------------------------------

--- a/tests/smoke/smoke_tests.cpp
+++ b/tests/smoke/smoke_tests.cpp
@@ -152,6 +152,31 @@ static void register_smoke_tests() {
                       "SELECT id FROM users",
                       "ORDER BY a hidden column does not change the projected column set");
     });
+
+    // ---- ORDER BY row SEQUENCE (order-SENSITIVE). Every other comparison in the
+    //   suite is bag_equal (multiset), so a Sort that drops or reverses the order
+    //   is completely invisible. Pin the actual row sequence against a literal
+    //   ordered oracle - the only check that can detect a wrong sort. emp
+    //   salaries: id5=90, id1=100, id4=120, id3=150, id2=200 (no NULLs).
+    //   Killed by M14 (Sort eval reverses the order).
+    test("smoke.order_by_sequence", [] {
+        auto asc = oracle("SELECT id FROM emp ORDER BY salary");
+        auto ra = eval(asc.optimized, data());
+        check(ra.has_value(), "ORDER BY salary ASC eval supported");
+        if (ra) {
+            Table expected = { {vi(5)}, {vi(1)}, {vi(4)}, {vi(3)}, {vi(2)} };
+            check(seq_equal(*ra, expected),
+                  "ORDER BY salary ASC yields ids in exactly [5,1,4,3,2]");
+        }
+        auto desc = oracle("SELECT id FROM emp ORDER BY salary DESC");
+        auto rd = eval(desc.optimized, data());
+        check(rd.has_value(), "ORDER BY salary DESC eval supported");
+        if (rd) {
+            Table expected = { {vi(2)}, {vi(3)}, {vi(4)}, {vi(1)}, {vi(5)} };
+            check(seq_equal(*rd, expected),
+                  "ORDER BY salary DESC yields ids in exactly [2,3,4,1,5]");
+        }
+    });
 }
 
 static bool _smoke_registered = (register_smoke_tests(), true);


### PR DESCRIPTION
## Summary

Every result comparison in the suite used `bag_equal` (multiset), so **row order was never verified** — a Sort that drops or reverses the ORDER BY direction was completely invisible. An audit confirmed it: injecting a sort-reversal into the evaluator **passed the whole suite**. A real blind spot in the falsifiability gate.

## Fix

- **`seq_equal()`** — an order-**sensitive** table comparator (rows must match position-by-position).
- **Mutant M14** — Sort eval reverses the row order (models a dropped/reversed ORDER BY direction).
- **`smoke.order_by_sequence`** — pins the actual row sequence of `SELECT id FROM emp ORDER BY salary` (ASC **and** DESC) against a **literal ordered oracle** via `seq_equal`. Being a literal anchor (not a query-vs-query check), it also doesn't depend on the evaluator being its own oracle.

M14 is invisible to every `bag_equal` check and is caught **only** by the new order-sensitive test, so the gate now enforces that ORDER BY ordering stays covered.

## Verification

- Clean suite **82/82**.
- **Gate passes**: 82 tests all falsifiable, 14 mutants all caught.
- Under `DB25_MUTANT=14`, **exactly** `smoke.order_by_sequence` fails (both the ASC and DESC checks), confirming the mutant is caught precisely by the new test.

_(One of two proven blind spots from a harness falsifiability audit; the RIGHT/FULL-JOIN `USING` coalesce blind spot is a separate follow-up.)_