### PR TITLE
harness: cover RIGHT/FULL USING/NATURAL column coalescing (M15 + test)

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -39,6 +39,10 @@
 //       direction). Invisible to every bag_equal (multiset) check; caught ONLY
 //       by the order-sensitive ORDER BY sequence test (seq_equal vs a literal
 //       ordered oracle).
+//   M15 COALESCE keeps only its first operand. Models a USING/NATURAL RIGHT/FULL
+//       merge that keeps the left copy instead of COALESCE(left, right), so the
+//       merged column is NULL for right-only rows. Caught by the RIGHT-JOIN-USING
+//       merged-value test (literal oracle over an all-right-only join).
 //
 // A test is FALSIFIABLE iff some mutant makes it fail. The gate reports any test
 // that survives every mutant as NON-FALSIFIABLE (vacuous) and exits non-zero.
@@ -469,6 +473,12 @@ Value eval_expr(const Expr* e, const Row& row, EvalCtx& ctx) {
                     Value v = eval_expr(c.get(), row, ctx);
                     if (!ctx.ok) return null();
                     if (!is_null(v)) return v;
+                    // M15: consider ONLY the first operand, dropping the rest. This
+                    // models a USING/NATURAL RIGHT/FULL merge that keeps only the
+                    // left copy instead of COALESCE(left, right): the merged column
+                    // becomes NULL for every right-only row. Invisible unless a
+                    // test pins the actual merged value.
+                    if (g_mutant == 15) break;
                 }
                 return null();
             }
@@ -1150,6 +1160,7 @@ const MutantInfo kMutants[] = {
     {12, "M12 second optimize() pass changes the plan (non-idempotent)"},
     {13, "M13 Sort eval leaks hidden ORDER BY sort keys (no truncation to output width)"},
     {14, "M14 Sort eval reverses the row order (wrong ORDER BY direction)"},
+    {15, "M15 COALESCE keeps only its first operand (USING/NATURAL merge loses the right copy)"},
 };
 }  // namespace
 

--- a/tests/corpus/joins_degenerate.cpp
+++ b/tests/corpus/joins_degenerate.cpp
@@ -151,6 +151,33 @@ static void register_joins_degenerate() {
             "FULL JOIN == LEFT JOIN + (RIGHT-only null-extended rows)");
     });
 
+    // 7b) RIGHT JOIN ... USING(id): the merged output column is
+    //     COALESCE(left.id, right.id). users.id (1..5) and orders.id (100..106)
+    //     are disjoint, so EVERY RIGHT-JOIN row is right-only (no left match) -
+    //     the exact case the coalesce matters: the merged id must take the RIGHT
+    //     value, never NULL. This was a total blind spot (the suite tested USING
+    //     only over INNER, and RIGHT/FULL only with ON). Pinned against a literal
+    //     oracle, and cross-checked against the explicit COALESCE/ON phrasing.
+    //     Killed by M15 (COALESCE keeps only its left operand -> all-NULL id).
+    test("join.right_using_coalesces_to_right", [] {
+        auto s = oracle("SELECT id FROM users u RIGHT JOIN orders o USING (id)");
+        auto ro = eval(s.optimized, data());
+        check(ro.has_value(), "RIGHT JOIN USING eval supported");
+        if (ro) {
+            Table expected = { {vi(100)}, {vi(101)}, {vi(102)}, {vi(103)},
+                               {vi(104)}, {vi(105)}, {vi(106)} };
+            check(bag_equal(*ro, expected),
+                  "RIGHT JOIN USING(id): merged id is the right value for every "
+                  "right-only row (never NULL)");
+        }
+        // The USING merge must equal an explicit COALESCE(left,right) over ON.
+        expect_bag_eq(
+            "SELECT id FROM users u RIGHT JOIN orders o USING (id)",
+            "SELECT COALESCE(u.id, o.id) FROM users u RIGHT JOIN orders o "
+            "ON u.id = o.id",
+            "USING merge == explicit COALESCE(left,right) over ON u.id=o.id");
+    });
+
     // 8) THE pushdown trap: a predicate on the NULL-SUPPLYING (right) side of a
     //    LEFT JOIN must NOT be pushed below the join. `WHERE o.amount IS NULL`
     //    legitimately selects BOTH null-extended non-matches AND real NULL


### PR DESCRIPTION
## Summary

The one shape where a USING/NATURAL merged column is a real `COALESCE` — **RIGHT/FULL** joins, where a right-only row must take the RIGHT value — had **zero coverage**: the suite tested `USING` only over `INNER` joins, and `RIGHT`/`FULL` only with `ON`. An audit confirmed the gap: dropping the right operand of the binder's `COALESCE(left, right)` merge (so the merged column is NULL for every right-only row) **passed the whole suite**.

## Fix

- **Mutant M15** — COALESCE eval keeps only its first operand, modelling a merge that loses the right copy.
- **`join.right_using_coalesces_to_right`** — `users.id` (1–5) and `orders.id` (100–106) are disjoint, so **every** row of `users RIGHT JOIN orders USING(id)` is right-only — the exact case the coalesce matters. It pins the merged `id` against a **literal oracle** `[100..106]` **and** cross-checks the USING merge against an explicit `COALESCE(u.id, o.id)` over an `ON` join.

The **real** binder bug (merge keeps only the left copy) is caught by **both**: the literal anchor sees all-NULL, and the cross-check sees `USING-merge ≠ explicit-COALESCE` (the binder bug affects only the USING merge, not a user-written COALESCE).

## Verification

- Clean suite **83/83**.
- **Gate passes**: 83 tests all falsifiable, 15 mutants all caught.
- Under `DB25_MUTANT=15`, the new test fails as intended (all-NULL merged column ≠ the literal oracle).

_(Second of the two proven blind spots from the harness falsifiability audit; the first — ORDER BY ordering — landed in #12.)_