### PR TITLE
harness: ground-truth oracle anchors + outer-join null-extension mutant

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -880,13 +880,17 @@ bool eval_node(const LogicalNode* n, EvalCtx& ctx, Table& out) {
                     }
                     if (keep) { emit(std::move(combined)); matched = true; right_matched[ri] = true; }
                 }
-                if (keep_left && !matched) {
+                // M16: drop the null-extended row an outer join must emit for an
+                // unmatched left row, degrading LEFT/FULL to an inner join. Caught
+                // by the outer-join null-extension anchors (a NULL-padded row that
+                // must appear goes missing).
+                if (keep_left && !matched && g_mutant != 16) {
                     Row combined = lr;
                     for (std::size_t k = 0; k < rw; ++k) combined.push_back(null());
                     emit(std::move(combined));
                 }
             }
-            if (keep_right) {
+            if (keep_right && g_mutant != 16) {  // M16: also drop right-side null-extension
                 for (std::size_t ri = 0; ri < right.size(); ++ri) {
                     if (right_matched[ri]) continue;
                     Row combined;
@@ -1218,6 +1222,7 @@ const MutantInfo kMutants[] = {
     {13, "M13 Sort eval leaks hidden ORDER BY sort keys (no truncation to output width)"},
     {14, "M14 Sort eval reverses the row order (wrong ORDER BY direction)"},
     {15, "M15 COALESCE keeps only its first operand (USING/NATURAL merge loses the right copy)"},
+    {16, "M16 outer-join eval drops null-extended rows (LEFT/RIGHT/FULL degrade to inner)"},
 };
 }  // namespace
 

--- a/tests/corpus/oracle_anchors.cpp
+++ b/tests/corpus/oracle_anchors.cpp
@@ -1,0 +1,139 @@
+// tests/corpus/oracle_anchors.cpp
+//
+// GROUND-TRUTH ORACLE ANCHORS.
+//
+// The bulk of the suite verifies the pipeline with the DIFFERENTIAL oracle:
+// eval(bound) == eval(optimized). That is powerful for catching an optimizer
+// that changes results, but it is near-self-referential about eval() itself --
+// both sides run through the SAME reference evaluator, so a SYSTEMATIC eval
+// defect (e.g. an outer join that never null-extends, an aggregate that is off
+// by a constant, a 3VL filter that mishandles NULL) is invisible: bound and
+// optimized agree on the wrong answer.
+//
+// These tests pin eval() to LITERAL hand-computed Tables over the data()
+// fixture, so the evaluator is checked against external truth rather than
+// against itself. Each anchor targets an area the differential oracle cannot
+// self-check: outer-join null extension, three-valued filtering, and multi-
+// aggregate group-by. Every anchor is falsifiable by at least one mutant
+// (noted per test); the gate proves that.
+//
+// data() ground truth used below (see harness.cpp data()):
+//   users   : (1,alice,30,NYC,-) (2,bob,NULL,LA,1) (3,carol,5,NYC,1)
+//             (4,dave,40,LA,2)   (5,eve,25,NULL,2)
+//   orders  : (100,u1,p10,50,paid) (101,u1,p11,5,paid) (102,u2,p12,30,pending)
+//             (103,u3,p13,NULL,paid) (104,uNULL,p10,8,paid) (105,u4,p12,120,-)
+//             (106,u9,p10,40,shipped)
+//   emp     : (1,-,10,100) (2,1,10,200) (3,1,20,150) (4,2,20,120) (5,-,10,90)
+//             [columns: id, mgr_id, dept_id, salary]
+
+#include "harness/harness.hpp"
+
+using namespace db25::harness;
+
+namespace {
+
+// Standard differential oracle plus stage assertions; returns the Stages so the
+// caller can pin the optimized plan's eval to a literal Table.
+Stages oracle(std::string_view sql) {
+    auto s = run(catalog(), sql);
+    check(s.parsed, "parsed");
+    check(s.analyze_ok, "analyze ok");
+    check(s.bind_ok, "bind ok");
+    check(s.optimize_ok, "optimize ok");
+    auto rb = eval(s.bound, data());
+    auto ro = eval(s.optimized, data());
+    if (rb && ro) check(bag_equal(*rb, *ro), "bound == optimized (differential oracle)");
+    return s;
+}
+
+// Run `sql`, then assert eval(optimized) equals the literal expected multiset.
+// `eval` returning nullopt (unsupported shape) is itself a failure here: an
+// anchor whose eval is silently skipped would be vacuous, which defeats the
+// point of the anchor.
+void expect_rows(std::string_view sql, const Table& expected, std::string_view what) {
+    auto s = oracle(sql);
+    auto ro = eval(s.optimized, data());
+    check(ro.has_value(), std::string("anchor eval supported: ") + std::string(what));
+    if (ro) check(bag_equal(*ro, expected), what);
+}
+
+}  // namespace
+
+static void register_oracle_anchors() {
+
+    // ---- 1. THREE-VALUED FILTER. `age > 20` is UNKNOWN for bob (NULL age), so
+    //   he is dropped, NOT kept. alice(30), dave(40), eve(25) pass; carol(5)
+    //   fails the comparison. Pins the 3VL truth table for a WHERE predicate
+    //   against a literal set -- the differential oracle cannot see a filter that
+    //   systematically keeps NULL rows because both plans would keep them.
+    //   Killed by M2 (Filter eval ignores the predicate -> all 5 users).
+    test("anchor.three_valued_filter", [] {
+        expect_rows("SELECT id FROM users WHERE age > 20",
+                    { {vi(1)}, {vi(4)}, {vi(5)} },
+                    "age > 20 keeps exactly {1,4,5} (NULL age dropped, not kept)");
+    });
+
+    // ---- 2. LEFT JOIN NULL EXTENSION. eve (user 5) has no orders; a LEFT JOIN
+    //   must still emit one row for her with a NULL right side. Matched users
+    //   pair with each of their orders. Orders 104 (user_id NULL) and 106
+    //   (user_id 9) match no user and do NOT appear (left join is driven by the
+    //   left side). Pinning the NULL-extended row is the only way to catch an
+    //   eval that silently degrades LEFT to INNER.
+    //   Killed by M16 (outer-join eval drops the (5, NULL) null-extended row).
+    test("anchor.left_join_null_extension", [] {
+        expect_rows(
+            "SELECT u.id, o.id FROM users u LEFT JOIN orders o ON o.user_id = u.id",
+            { {vi(1), vi(100)}, {vi(1), vi(101)}, {vi(2), vi(102)},
+              {vi(3), vi(103)}, {vi(4), vi(105)}, {vi(5), null()} },
+            "LEFT JOIN keeps eve as (5, NULL); orders 104/106 excluded");
+    });
+
+    // ---- 3. RIGHT JOIN NULL EXTENSION. Now the orders side is preserved:
+    //   orders 104 (user_id NULL) and 106 (user_id 9) match no user and appear
+    //   as (NULL, 104) / (NULL, 106). The matched orders pair with their user.
+    //   Killed by M16 (the two (NULL, order) right-preserved rows go missing).
+    test("anchor.right_join_null_extension", [] {
+        expect_rows(
+            "SELECT u.id, o.id FROM users u RIGHT JOIN orders o ON o.user_id = u.id",
+            { {vi(1), vi(100)}, {vi(1), vi(101)}, {vi(2), vi(102)}, {vi(3), vi(103)},
+              {vi(4), vi(105)}, {null(), vi(104)}, {null(), vi(106)} },
+            "RIGHT JOIN keeps unmatched orders 104/106 as (NULL, id)");
+    });
+
+    // ---- 4. FULL JOIN NULL EXTENSION. Both sides preserved: eve's (5, NULL)
+    //   AND the two unmatched orders (NULL, 104)/(NULL, 106), on top of every
+    //   matched pair. This is the union of the LEFT and RIGHT anchors.
+    //   Killed by M16 (all three null-extended rows drop, leaving only matches).
+    test("anchor.full_join_null_extension", [] {
+        expect_rows(
+            "SELECT u.id, o.id FROM users u FULL JOIN orders o ON o.user_id = u.id",
+            { {vi(1), vi(100)}, {vi(1), vi(101)}, {vi(2), vi(102)}, {vi(3), vi(103)},
+              {vi(4), vi(105)}, {vi(5), null()}, {null(), vi(104)}, {null(), vi(106)} },
+            "FULL JOIN keeps eve AND unmatched orders 104/106");
+    });
+
+    // ---- 5. MULTI-AGGREGATE GROUP BY. Two aggregates in one group, pinned to a
+    //   literal Table (not query-vs-query), so an eval-side SUM/COUNT defect is
+    //   caught rather than cancelling out. emp dept 10 = ids {1,2,5}
+    //   (salaries 100+200+90 = 390, count 3); dept 20 = ids {3,4}
+    //   (150+120 = 270, count 2).
+    //   Killed by M4 (COUNT/SUM off by one -> {10:4:391, 20:3:271}).
+    test("anchor.group_by_count_sum", [] {
+        expect_rows(
+            "SELECT dept_id, COUNT(*), SUM(salary) FROM emp GROUP BY dept_id",
+            { {vi(10), vi(3), vi(390)}, {vi(20), vi(2), vi(270)} },
+            "GROUP BY dept_id -> {10:3:390, 20:2:270}");
+    });
+
+    // ---- 6. COUNT(nullable) vs COUNT(*). order 103 has a NULL amount, so
+    //   COUNT(amount) = 6 while COUNT(*) = 7. A single literal row pins the exact
+    //   NULL-skipping semantics of COUNT(expr) against COUNT(*).
+    //   Killed by M9 (COUNT(expr) counts the NULL row -> 7) and M4 (off by one).
+    test("anchor.count_nullable_vs_star", [] {
+        expect_rows("SELECT COUNT(amount), COUNT(*) FROM orders",
+                    { {vi(6), vi(7)} },
+                    "COUNT(amount)=6 (NULL skipped), COUNT(*)=7");
+    });
+}
+
+static bool _oracle_anchors_registered = (register_oracle_anchors(), true);

--- a/tests/corpus/subqueries.cpp
+++ b/tests/corpus/subqueries.cpp
@@ -102,9 +102,14 @@ static void register_subqueries() {
     //    the optimizer keeps, bound and optimized must still agree. Pure oracle.
     test("subq.not_in_nullable_stays_correct", [] {
         // orders.user_id is nullable -> decorrelation to AntiJoin is illegal.
-        oracle("SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM orders)");
-        // TODO(oracle): if eval cannot run the retained-subquery form, only the
-        // stage checks fire; that still fails on a broken pipeline (non-vacuous).
+        // Independent ground-truth anchor (not just the self-referential oracle):
+        // orders.user_id contains a NULL (order 104), so `id NOT IN (...)` is
+        // UNKNOWN for EVERY user under 3VL -> the result is empty. A rewrite to an
+        // AntiJoin (which ignores the NULL) would instead return eve (user 5), so
+        // this empty-result anchor is exactly what falsifies an illegal
+        // decorrelation. Killed by M2 (Filter ignored -> all 5 users returned).
+        expect_empty("SELECT id FROM users WHERE id NOT IN (SELECT user_id FROM orders)",
+                     "NOT IN over a NULL-bearing inner is UNKNOWN everywhere -> empty");
     });
 
     // 6) Nested subquery (subquery within subquery) == a two-join equivalent.
@@ -123,14 +128,24 @@ static void register_subqueries() {
     //    query's row (u.age), past the middle subquery. Decorrelation must not
     //    lose that correlation. Oracle-only (no simple flat equivalent).
     test("subq.skip_level_correlation", [] {
-        oracle(
+        auto s = oracle(
             "SELECT u.id FROM users u WHERE EXISTS ("
             "  SELECT 1 FROM orders o WHERE o.user_id = u.id AND EXISTS ("
             "    SELECT 1 FROM products p WHERE p.id = o.product_id "
             "      AND p.price > u.age))");
-        // TODO(oracle): if the nested-correlated shape is unsupported by eval,
-        // the stage checks still guard correctness; the differential claim is
-        // then unverified (documented here, not silently passed).
+        // Independent ground-truth anchor for the skip-level correlation (the
+        // inner EXISTS references u.age from the OUTERMOST block). Hand-computed:
+        //   u1 age30: orders p10(price9),p11(NULL) -> 9>30 F, NULL>30 UNK -> no
+        //   u2 ageNULL: order p12(75) -> 75>NULL UNK -> no
+        //   u3 age5:  order p13(150) -> 150>5 T -> YES
+        //   u4 age40: order p12(75)  -> 75>40 T -> YES
+        //   u5 age25: no orders -> no
+        // => exactly {3, 4}. Killed by M2 (inner Filter ignored -> every user
+        // with any order qualifies) and M3 (SemiJoin keeps all left rows).
+        auto ro = eval(s.optimized, data());
+        check(ro.has_value(), "skip-level correlation eval supported");
+        if (ro) check(bag_equal(*ro, Table{ {vi(3)}, {vi(4)} }),
+                      "skip-level correlated EXISTS yields exactly {3,4}");
     });
 
     // 8) Correlated scalar SUM decorrelates to a LEFT JOIN grouped by the
@@ -176,9 +191,18 @@ static void register_subqueries() {
     //     MIN, so the two result sets must NOT be equal (falsifier if the scalar
     //     is folded to a constant that collapses them).
     test("subq.scalar_in_where_comparison", [] {
-        oracle("SELECT id FROM orders WHERE amount > (SELECT AVG(amount) FROM orders)");
-        // TODO(oracle): if scalar-subquery-in-predicate eval is unsupported the
-        // oracle stage checks still guard the pipeline.
+        auto s = oracle("SELECT id FROM orders WHERE amount > (SELECT AVG(amount) FROM orders)");
+        // Independent ground-truth anchor. Non-NULL amounts: 50,5,30,8,120,40
+        // (order 103's amount is NULL and is excluded from AVG). AVG = 253/6 =
+        // 42.17. amount > 42.17 -> only order 100 (50) and order 105 (120); order
+        // 103's NULL amount also fails the comparison (UNKNOWN). => exactly
+        // {100, 105}. This pins the scalar-subquery-in-predicate result instead
+        // of leaving it to the self-referential oracle. Killed by M2 (Filter
+        // ignored -> all 7 orders).
+        auto ro = eval(s.optimized, data());
+        check(ro.has_value(), "scalar-subquery-in-predicate eval supported");
+        if (ro) check(bag_equal(*ro, Table{ {vi(100)}, {vi(105)} }),
+                      "amount > AVG(amount) yields exactly {100,105}");
     });
 
     // 11) Subquery in the SELECT list mixed with arithmetic. The +1 must apply


### PR DESCRIPTION
## Why

The suite verifies the pipeline mainly with the **differential oracle** — `eval(bound) == eval(optimized)`. That is powerful against an optimizer that changes results, but it is *near-self-referential about the reference evaluator itself*: both sides run through the same `eval()`, so a **systematic eval defect** is invisible — both plans agree on the wrong answer. Nothing pinned outer-join null extension, three-valued filtering, or multi-aggregate group-by to external ground truth.

## What

**`tests/corpus/oracle_anchors.cpp`** — six literal-`Table` anchors over the `data()` fixture, each hand-computed and each falsifiable by a named mutant:

| Anchor | Ground truth | Killed by |
|---|---|---|
| `three_valued_filter` | `age > 20` → `{1,4,5}` (NULL age dropped, not kept) | M2 |
| `left_join_null_extension` | eve as `(5, NULL)`; orders 104/106 excluded | M16 |
| `right_join_null_extension` | unmatched orders as `(NULL,104)`, `(NULL,106)` | M16 |
| `full_join_null_extension` | eve **and** unmatched orders | M16 |
| `group_by_count_sum` | `{10:3:390, 20:2:270}` | M4 |
| `count_nullable_vs_star` | `COUNT(amount)=6, COUNT(*)=7` | M9 / M4 |

**New mutant M16** — outer-join eval drops null-extended rows, degrading LEFT/RIGHT/FULL to inner. Outer-join null extension previously had **no** mutant guarding it, so a literal anchor over it would have been non-falsifiable and the gate would have rejected it. M16 closes that gap; it is caught by the new anchors and by the pre-existing outer-join tests (10 tests total).

**Three previously-vacuous subquery tests** in `tests/corpus/subqueries.cpp` (oracle-only, no independent check) replaced with ground-truth anchors:
- `not_in_nullable_stays_correct`: NOT IN over a NULL-bearing inner is UNKNOWN everywhere → empty.
- `skip_level_correlation`: outermost-referencing EXISTS → exactly `{3,4}`.
- `scalar_in_where_comparison`: `amount > AVG(amount)` → exactly `{100,105}`.

All three are now killed by M2 (they survived every mutant before).

## Verification

- `db25_harness`: **90 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 90 tests falsifiable; every mutant M1–M16 caught.
- Confirmed the intended mapping directly: `DB25_MUTANT=16` fails the three outer-join anchors; `DB25_MUTANT=2` fails the 3VL filter anchor and all three de-vacuumed subquery tests.

Test-only change; no production/library code touched.