### PR TITLE
harness: stage-artifact conformance suite for end-to-end SQL coverage

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -53,6 +53,7 @@
 #include "db25/plan/optimizer.hpp"
 #include "db25/parser/parser.hpp"
 #include "db25/semantic/analyzer.hpp"
+#include "db25/ast/ast_node.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -1135,6 +1136,29 @@ std::size_t count_subqueries(const LogicalNode* n) {
     return total;
 }
 
+// --- Stage-artifact predicates over the fingerprints captured by run() ---
+bool ast_has(const Stages& s, db25::ast::NodeType kind) {
+    for (const auto k : s.ast_kinds) {
+        if (k == kind) return true;
+    }
+    return false;
+}
+
+bool has_diagnostic(const Stages& s, db25::semantic::DiagnosticCode code) {
+    for (const auto& d : s.diags) {
+        if (d.code == code) return true;
+    }
+    return false;
+}
+
+std::size_t error_count(const Stages& s) {
+    std::size_t n = 0;
+    for (const auto& d : s.diags) {
+        if (d.severity == db25::semantic::Severity::Error) ++n;
+    }
+    return n;
+}
+
 // ===========================================================================
 // Pipeline driver.
 // ===========================================================================
@@ -1153,6 +1177,20 @@ bool drop_first_predicate(LogicalNode* n) {
 }
 }  // namespace
 
+// Depth-first walk of the parsed AST, recording every NodeType encountered.
+// This is the parse-stage "feature fingerprint" a conformance test asserts
+// against (e.g. a query that uses a window function must yield a WindowFunction
+// node here). The AST is arena-owned by the Parser, so this runs while the
+// Parser is still alive inside run() and copies only the small kind vector out.
+static void collect_ast_kinds(const db25::ast::ASTNode* n,
+                              std::vector<db25::ast::NodeType>& out) {
+    if (n == nullptr) return;
+    out.push_back(n->node_type);
+    for (const db25::ast::ASTNode* c = n->first_child; c != nullptr; c = c->next_sibling) {
+        collect_ast_kinds(c, out);
+    }
+}
+
 Stages run(const db25::semantic::InMemoryCatalog& cat, std::string_view sql) {
     Stages st;
     db25::parser::Parser parser;
@@ -1160,9 +1198,15 @@ Stages run(const db25::semantic::InMemoryCatalog& cat, std::string_view sql) {
     st.parsed = parsed.has_value();
     if (!st.parsed) return st;
 
+    // Parse-stage artifact: fingerprint the AST before it is discarded.
+    collect_ast_kinds(parsed.value(), st.ast_kinds);
+
     db25::semantic::Analyzer analyzer(cat);
     analyzer.analyze(parsed.value());
     st.analyze_ok = !analyzer.has_errors();
+    // Analyze-stage artifact: snapshot the diagnostics (the analyzer is a
+    // run()-local and will not outlive this call).
+    st.diags = analyzer.diagnostics();
 
     // Bind twice so the pre- and post-optimization plans are both live.
     db25::plan::Binder binder_a(analyzer, cat);

--- a/harness/harness.hpp
+++ b/harness/harness.hpp
@@ -21,6 +21,8 @@
 #include "db25/plan/logical_plan.hpp"
 #include "db25/plan/expr_ir.hpp"
 #include "db25/semantic/catalog.hpp"
+#include "db25/semantic/diagnostic.hpp"
+#include "db25/ast/node_types.hpp"
 
 #include <cstdint>
 #include <functional>
@@ -74,6 +76,20 @@ struct Stages {
     std::string bound_dump;
     std::string optimized_dump;
 
+    // --- Stage-artifact fingerprints (for the conformance suite) ---
+    // The parser's AST and the analyzer's diagnostics live only *inside* run()
+    // (the AST is arena-owned by the Parser, which is a run()-local). To let a
+    // conformance test assert what each pipeline STAGE produced - not just the
+    // final plan - run() snapshots their salient contents here while they are
+    // still alive. `ast_kinds` is every NodeType present in the parsed tree (the
+    // parse-stage feature fingerprint); `diags` is a copy of the analyzer's
+    // diagnostics (the analyze-stage effect). Plan-stage propagation is asserted
+    // directly against `bound` / `optimized` with plan_contains(). Together they
+    // let a test verify a feature seen at parse time actually reaches - and
+    // transforms into - the expected downstream artifact.
+    std::vector<db25::ast::NodeType> ast_kinds;
+    std::vector<db25::semantic::Diagnostic> diags;
+
     // Owners - keep the plans alive for the lifetime of the Stages value. Held
     // by shared_ptr so Stages is copyable (the test suites pass Stages around by
     // value and store them in `const` locals); copies share the same plans. The
@@ -107,6 +123,17 @@ struct Stages {
 // ---------------------------------------------------------------------------
 [[nodiscard]] bool plan_contains(const db25::plan::LogicalNode* n, db25::plan::LogicalOp op);
 [[nodiscard]] std::size_t count_subqueries(const db25::plan::LogicalNode* n);
+
+// ---------------------------------------------------------------------------
+// Stage-artifact predicates (for the conformance suite). These read the
+// per-stage fingerprints captured on Stages so a test can assert that a SQL
+// feature (a) was parsed, (b) produced / avoided a given analyzer diagnostic,
+// and (c) propagated to the expected LogicalOp - i.e. its EFFECT survived into
+// each subsequent artifact, not just that the query ran.
+// ---------------------------------------------------------------------------
+[[nodiscard]] bool ast_has(const Stages& s, db25::ast::NodeType kind);
+[[nodiscard]] bool has_diagnostic(const Stages& s, db25::semantic::DiagnosticCode code);
+[[nodiscard]] std::size_t error_count(const Stages& s);
 
 // ---------------------------------------------------------------------------
 // Shared default schema + data (rich enough for pessimistic tests).

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -1,0 +1,225 @@
+// tests/conformance/conformance.cpp
+//
+// END-TO-END STAGE CONFORMANCE. The corpus/property/metamorphic suites assert
+// RESULT correctness (does the pipeline compute the right rows?). This suite
+// asserts STAGE PROPAGATION: for a feature used in a query, does its effect
+// actually appear in every downstream artifact the pipeline produces -
+//   parse (AST)  ->  analyze (diagnostics)  ->  bind (LogicalOp)  ->  result?
+// It reads the per-stage fingerprints run() now records on Stages (ast_kinds,
+// diags) plus the live bound/optimized plans, so a regression that silently
+// drops a feature between two stages (the exact failure mode the grammar audit
+// found: WITH parses but never lowers, ON CONFLICT parses but is discarded)
+// is caught here even when the final row count happens to look plausible.
+//
+// Two axes, per the design:
+//   (1) COVERAGE  - a feature manifest that fails if a supported feature is not
+//       exercised, or its AST node / LogicalOp does not appear.
+//   (2) EFFECT    - every case also pins the RESULT bag, so the feature's
+//       semantic effect in the final artifact is verified (and the test stays
+//       falsifiable under the mutant catalog - a purely structural check would
+//       survive every mutant and the gate would reject it).
+//
+// This is an EXTENSION of the existing harness (run/eval/test/check/the gate),
+// not a new framework: it only adds a new suite file and reads fields run()
+// already captures.
+
+#include "harness/harness.hpp"
+
+using namespace db25::harness;
+using db25::plan::LogicalOp;
+using NT = db25::ast::NodeType;
+
+namespace {
+
+// Drive the pipeline and assert every stage SUCCEEDED (a conformance case is
+// about a feature that is supposed to work end to end). Returns Stages so the
+// caller can assert per-stage artifacts.
+Stages conform(std::string_view sql) {
+    auto s = run(catalog(), sql);
+    check(s.parsed, "parsed");
+    check(s.analyze_ok, "analyze ok");
+    check(s.bind_ok, std::string("bind ok") + (s.bind_ok ? "" : (": " + s.bind_error)));
+    check(s.optimize_ok, "optimize ok");
+    return s;
+}
+
+}  // namespace
+
+static void register_conformance_tests() {
+
+    // ---- CQ1. Analytical kitchen-sink: JOIN + WHERE(scalar subquery) + GROUP BY
+    //   + HAVING(aggregate). Verifies each clause's node reaches the AST, analysis
+    //   is clean, the plan carries the matching operators, and the result is
+    //   exact. Rows after join+filter amount > AVG(amount)=42.17: order100
+    //   (u1,NYC,50), order105 (u4,LA,120). Groups NYC{n1,50}, LA{n1,120}; both
+    //   pass HAVING SUM>0.  (ORDER BY over an aggregate is deliberately NOT used
+    //   here - it currently corrupts the aggregate columns to NULL, tracked as a
+    //   separate correctness finding; adding it would make this a bug reproducer,
+    //   not a conformance baseline.)
+    //   Killed by M2 (filter ignored) and M4 (aggregate off by one).
+    //   (Aggregate aliases in the SELECT list are avoided: a HAVING that repeats
+    //   an ALIASED select aggregate currently fails to match it and drops every
+    //   row - a separate correctness finding, kept out of this baseline.)
+    test("conformance.analytical_kitchen_sink", [] {
+        auto s = conform(
+            "SELECT u.city, COUNT(*), SUM(o.amount) "
+            "FROM users u JOIN orders o ON o.user_id = u.id "
+            "WHERE o.amount > (SELECT AVG(amount) FROM orders) "
+            "GROUP BY u.city HAVING SUM(o.amount) > 0");
+        // Parse-stage: every clause's node is present.
+        check(ast_has(s, NT::JoinClause),   "AST has JOIN");
+        check(ast_has(s, NT::WhereClause),  "AST has WHERE");
+        check(ast_has(s, NT::Subquery),     "AST has scalar subquery");
+        check(ast_has(s, NT::GroupByClause),"AST has GROUP BY");
+        check(ast_has(s, NT::HavingClause), "AST has HAVING");
+        // Analyze-stage: no diagnostics.
+        check(error_count(s) == 0, "analyzer reports no errors");
+        // Bind-stage: each feature lowered to its operator.
+        check(plan_contains(s.bound, LogicalOp::Join),      "plan has Join");
+        check(plan_contains(s.bound, LogicalOp::Aggregate), "plan has Aggregate");
+        check(plan_contains(s.bound, LogicalOp::Filter),    "plan has Filter (HAVING/WHERE)");
+        // Result-stage: exact rows, and bound == optimized (differential).
+        auto rb = eval(s.bound, data());
+        auto ro = eval(s.optimized, data());
+        if (rb && ro) check(bag_equal(*rb, *ro), "bound == optimized (differential)");
+        if (ro) {
+            Table expected = { {vs("NYC"), vi(1), vi(50)}, {vs("LA"), vi(1), vi(120)} };
+            check(bag_equal(*ro, expected),
+                  "result is {(NYC,1,50),(LA,1,120)} (amount>AVG, grouped by city)");
+        }
+    });
+
+    // ---- CQ2. Subquery-decorrelation propagation: a correlated EXISTS must, by
+    //   the OPTIMIZE stage, become a SemiJoin with NO residual subquery - the
+    //   feature's *effect* is a plan transform, not just a result. DISTINCT must
+    //   also lower. Killed by M1 (optimizer disabled -> subquery survives, no
+    //   SemiJoin) and M2/M3 (wrong rows).
+    test("conformance.correlated_exists_decorrelates", [] {
+        auto s = conform(
+            "SELECT DISTINCT u.city FROM users u "
+            "WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id)");
+        check(ast_has(s, NT::Subquery), "AST has subquery (EXISTS)");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::Distinct), "bound plan has Distinct");
+        // The decorrelation EFFECT: optimize turns the subquery into a SemiJoin.
+        check(plan_contains(s.optimized, LogicalOp::SemiJoin),
+              "optimize lowered EXISTS to a SemiJoin");
+        check(count_subqueries(s.optimized) == 0,
+              "optimize left no residual subquery");
+        auto ro = eval(s.optimized, data());
+        if (ro) {
+            Table expected = { {vs("NYC")}, {vs("LA")} };
+            check(bag_equal(*ro, expected),
+                  "distinct cities of users-with-orders == {NYC, LA}");
+        }
+    });
+
+    // ---- CQ3. Set operation carrying a NULL through UNION distinct. Exercises
+    //   the SetOp path and NULL de-duplication. users.id {1..5} UNION
+    //   orders.user_id {1,2,3,4,9,NULL} -> {1,2,3,4,5,9,NULL}. Killed by M2
+    //   (branch filter ignored changes the bag) and M8-adjacent set semantics.
+    test("conformance.setop_union_with_null", [] {
+        auto s = conform(
+            "SELECT id FROM users WHERE age > 20 "
+            "UNION SELECT user_id FROM orders WHERE amount > 40");
+        check(ast_has(s, NT::UnionStmt), "AST has UNION");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::SetOp), "plan has SetOp");
+        auto ro = eval(s.optimized, data());
+        if (ro) {
+            // users age>20 -> {1,4,5}; orders amount>40 -> user_ids {1,4}.
+            // UNION distinct -> {1,4,5}.
+            Table expected = { {vi(1)}, {vi(4)}, {vi(5)} };
+            check(bag_equal(*ro, expected), "UNION distinct == {1,4,5}");
+        }
+    });
+
+    // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
+    //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
+    //   result. The result anchors keep this test falsifiable (M2/M4/... kill the
+    //   filter/aggregate/etc. rows) and verify the feature's effect in the final
+    //   artifact. The `window` row documents the current eval BOUNDARY: the
+    //   feature propagates all the way to a Window LogicalOp but the reference
+    //   evaluator does not implement it yet (eval -> nullopt), which this pins
+    //   explicitly rather than skipping silently.
+    test("conformance.feature_manifest", [] {
+        struct Feat {
+            const char* name;
+            const char* sql;
+            NT ast_kind;
+            bool expect_op;
+            LogicalOp op;
+            bool eval_supported;
+            Table want;  // expected optimized-eval bag when eval_supported
+        };
+        const std::vector<Feat> feats = {
+            {"inner_join",
+             "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id",
+             NT::JoinClause, true, LogicalOp::Join, true,
+             {{vi(1)},{vi(1)},{vi(2)},{vi(3)},{vi(4)}}},
+            {"left_join",
+             "SELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id",
+             NT::JoinClause, true, LogicalOp::Join, true,
+             {{vi(1)},{vi(1)},{vi(2)},{vi(3)},{vi(4)},{vi(5)}}},
+            {"where_filter",
+             "SELECT id FROM users WHERE age > 20",
+             NT::WhereClause, true, LogicalOp::Filter, true,
+             {{vi(1)},{vi(4)},{vi(5)}}},
+            {"group_by",
+             "SELECT dept_id, COUNT(*) FROM emp GROUP BY dept_id",
+             NT::GroupByClause, true, LogicalOp::Aggregate, true,
+             {{vi(10),vi(3)},{vi(20),vi(2)}}},
+            {"having",
+             "SELECT dept_id, COUNT(*) FROM emp GROUP BY dept_id HAVING COUNT(*) > 2",
+             NT::HavingClause, true, LogicalOp::Aggregate, true,
+             {{vi(10),vi(3)}}},
+            {"order_by_limit",
+             "SELECT id FROM emp ORDER BY id LIMIT 2",
+             NT::LimitClause, true, LogicalOp::Limit, true,
+             {{vi(1)},{vi(2)}}},
+            {"union",
+             "SELECT id FROM users UNION SELECT user_id FROM orders",
+             NT::UnionStmt, true, LogicalOp::SetOp, true,
+             {{vi(1)},{vi(2)},{vi(3)},{vi(4)},{vi(5)},{vi(9)},{null()}}},
+            {"between",
+             "SELECT id FROM users WHERE age BETWEEN 10 AND 40",
+             NT::BetweenExpr, true, LogicalOp::Filter, true,
+             {{vi(1)},{vi(4)},{vi(5)}}},
+            {"in_list",
+             "SELECT id FROM users WHERE id IN (1, 2, 3)",
+             NT::InExpr, true, LogicalOp::Filter, true,
+             {{vi(1)},{vi(2)},{vi(3)}}},
+            {"like",
+             "SELECT name FROM users WHERE name LIKE 'a%'",
+             NT::LikeExpr, true, LogicalOp::Filter, true,
+             {{vs("alice")}}},
+            {"case",
+             "SELECT id, CASE WHEN age > 20 THEN 1 ELSE 0 END FROM users",
+             NT::CaseExpr, false, LogicalOp::Project, true,
+             {{vi(1),vi(1)},{vi(2),vi(0)},{vi(3),vi(0)},{vi(4),vi(1)},{vi(5),vi(1)}}},
+            {"window_boundary",
+             "SELECT id, RANK() OVER (PARTITION BY dept_id ORDER BY salary DESC) FROM emp",
+             NT::WindowSpec, true, LogicalOp::Window, false, {}},
+        };
+
+        for (const auto& f : feats) {
+            const std::string tag = std::string("feature[") + f.name + "] ";
+            auto s = conform(f.sql);
+            check(ast_has(s, f.ast_kind), tag + "AST node present");
+            check(error_count(s) == 0, tag + "analyzer clean");
+            if (f.expect_op) {
+                check(plan_contains(s.bound, f.op), tag + "lowered to expected LogicalOp");
+            }
+            auto ro = eval(s.optimized, data());
+            if (f.eval_supported) {
+                check(ro.has_value(), tag + "eval supported");
+                if (ro) check(bag_equal(*ro, f.want), tag + "result effect matches");
+            } else {
+                check(!ro.has_value(),
+                      tag + "eval BOUNDARY: propagates to plan, evaluator not yet implemented");
+            }
+        }
+    });
+}
+
+static bool _conformance_registered = (register_conformance_tests(), true);


### PR DESCRIPTION
## Why

The corpus/property/metamorphic suites assert **result** correctness. Nothing asserted **stage propagation** — that a SQL feature used in a query actually appears in, and correctly transforms through, *every artifact the pipeline produces*: AST → analyzer diagnostics → logical plan → result. The grammar audit showed exactly why that gap matters: several features parse into an AST and are then **silently dropped** at the analyzer/binder boundary (WITH never lowers, ON CONFLICT is discarded), which a result-only check can't see when the row count happens to look plausible.

## What (extension of the existing harness — no new framework)

- **`Stages` now snapshots the two artifacts that previously lived only inside `run()`** and were discarded: `ast_kinds` (every `NodeType` in the parsed tree — the parse-stage feature fingerprint) and `diags` (the analyzer's diagnostics). `run()` captures them while the parser/analyzer are still alive, so `Stages` stays self-contained.
- **New predicates** `ast_has()` / `has_diagnostic()` / `error_count()` read those fingerprints; plan propagation is asserted with the existing `plan_contains()`.
- **`tests/conformance/conformance.cpp`** — a new *suite* (same status as `corpus/`/`smoke/`: registers via `test()`, GLOBbed into both executables). Two axes, per the design ask:
  1. **Coverage** — a 12-entry feature manifest that fails if a supported feature isn't exercised or its AST node / `LogicalOp` doesn't appear (joins, filters, grouping, having, set ops, BETWEEN/IN/LIKE/CASE, window).
  2. **Effect** — every case pins an exact result anchor, so the feature's effect in the final artifact is verified *and* each test stays falsifiable under the mutant catalog (a purely structural check would survive every mutant and the gate would reject it).
- Three complex end-to-end queries: join + scalar-subquery WHERE + GROUP BY + HAVING; correlated-EXISTS decorrelating to a SemiJoin (asserts the *transform*, not just rows); UNION carrying a NULL. The window path is pinned as an explicit **eval boundary** (propagates to a `Window` `LogicalOp`; the reference evaluator doesn't implement it yet) rather than skipped silently.

## Verification

- `db25_harness`: **94 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 94 tests falsifiable; every mutant M1–M16 caught.

## Bugs surfaced while authoring (filed for the correctness track, not fixed here)

The suite immediately earned its keep — two real aggregate-output-column-matching defects, both silent (wrong/empty result, no diagnostic), both present in the *bound* plan (binder-level, not the optimizer):

1. **`ORDER BY` over an aggregate result corrupts the aggregate columns to NULL.** `SELECT u.city, COUNT(*), SUM(o.amount) … GROUP BY u.city ORDER BY SUM(o.amount) DESC` returns the group rows with NULL `COUNT`/`SUM`. `ORDER BY` on a *base* column is unaffected.
2. **A `HAVING` that repeats an *aliased* SELECT aggregate fails to match it and drops every row.** `SELECT …, SUM(o.amount) AS total … HAVING SUM(o.amount) > 0` → empty; the identical query *without* the alias returns the correct rows. (Related to the earlier HAVING-matching fix, which covered COUNT but not this alias case.)

Consequence of (1)+(2): `HAVING … ORDER BY <aggregate>` together → empty. CQ1 is deliberately scoped around both so this PR is a clean baseline, not a bug reproducer; the reproducers are recorded here for the follow-up fix.

Test-only change; no production/library code touched.