### PR TITLE
harness: fix reference evaluator dropping aliased aggregate columns

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -657,10 +657,24 @@ Value compute_aggregate(const Expr* call, const std::vector<Row>& group_rows, Ev
 }
 
 // Map each Aggregate output column to its producer value (group key or aggregate)
-// and build the group's output row. See the design note in the report: aggregate
-// output columns are named by func_name; group-key columns by their source
-// column (and carry provenance column_id/table_id). Aggregates are consumed in
-// select-list order; group keys are matched by source id / name / type.
+// and build the group's output row. The output is select-list-shaped: each column
+// is EITHER a group-key passthrough (carrying its source column's provenance /
+// name) OR an aggregate result. We identify the group-key columns first, by
+// provenance then by name, and treat every remaining column as the next
+// aggregate value in select-list order.
+//
+// This deliberately does NOT identify an aggregate column by matching its name to
+// the aggregate's func_name: an alias (`SUM(x) AS s`) renames the output column,
+// so a func_name test silently fails to place the value and the column collapses
+// to NULL - which corrupted every aliased aggregate (and, transitively, any
+// HAVING / ORDER BY over one). Consuming the non-group-key columns positionally
+// is alias-agnostic.
+//
+// Residual limitation: a group key that is a non-column EXPRESSION (e.g.
+// `GROUP BY a + b`) carries no column provenance or source name, so it cannot be
+// distinguished from an aggregate here and would be mis-consumed if interleaved
+// with one. The corpus does not exercise expression group keys; revisit if it
+// starts to.
 Row build_aggregate_output_row(const LogicalNode* agg, const std::vector<Value>& gk_vals,
                                const std::vector<Value>& agg_vals) {
     const db25::plan::Schema& in = agg->child(0)->output;
@@ -670,16 +684,19 @@ Row build_aggregate_output_row(const LogicalNode* agg, const std::vector<Value>&
     std::vector<bool> gk_used(agg->group_keys.size(), false);
 
     for (const auto& col : agg->output) {
-        // Aggregate column? Its output name equals the next aggregate's func_name.
+        // (A) Unaliased aggregate: its output name is the next aggregate's
+        //     func_name. This is the fast, unambiguous path and covers every
+        //     query that does not alias its aggregates (incl. the decorrelated
+        //     LEFT JOIN + Aggregate the optimizer builds).
         if (agg_cursor < agg->aggregates.size() &&
             col.name == agg->aggregates[agg_cursor]->func_name) {
             out.push_back(agg_cursor < agg_vals.size() ? agg_vals[agg_cursor] : null());
             ++agg_cursor;
             continue;
         }
-        // Otherwise a group-key passthrough: match to a group_keys entry.
+        // (B) Group-key passthrough: match to a group_keys entry by source column
+        //     id / table id, then by source column name.
         int chosen = -1;
-        // (1) by source column id / table id.
         for (std::size_t i = 0; i < agg->group_keys.size(); ++i) {
             if (gk_used[i]) continue;
             const Expr* gk = agg->group_keys[i].get();
@@ -688,7 +705,6 @@ Row build_aggregate_output_row(const LogicalNode* agg, const std::vector<Value>&
             if (col.column_id != 0 && in[gk->input_index].column_id == col.column_id &&
                 in[gk->input_index].table_id == col.table_id) { chosen = static_cast<int>(i); break; }
         }
-        // (2) by name.
         if (chosen < 0) {
             for (std::size_t i = 0; i < agg->group_keys.size(); ++i) {
                 if (gk_used[i]) continue;
@@ -697,13 +713,30 @@ Row build_aggregate_output_row(const LogicalNode* agg, const std::vector<Value>&
                     !col.name.empty() && in[gk->input_index].name == col.name) { chosen = static_cast<int>(i); break; }
             }
         }
-        // (3) first unused.
-        if (chosen < 0) {
-            for (std::size_t i = 0; i < agg->group_keys.size(); ++i)
-                if (!gk_used[i]) { chosen = static_cast<int>(i); break; }
-        }
         if (chosen >= 0) {
-            gk_used[chosen] = true;
+            gk_used[static_cast<std::size_t>(chosen)] = true;
+            out.push_back(gk_vals[static_cast<std::size_t>(chosen)]);
+            continue;
+        }
+        // (C) A NON-EMPTY-named column that is neither a func_name match nor a
+        //     group key is an ALIASED aggregate (`SUM(x) AS s` renamed the
+        //     column). Consume the next aggregate value positionally - the fix for
+        //     the alias -> NULL bug. The agg_cursor is shared with path (A), so
+        //     mixed aliased/unaliased aggregates stay in select-list order.
+        //     The name test is what separates this from (D): decorrelation emits a
+        //     group-key passthrough with an EMPTY name and no provenance, which
+        //     must NOT steal an aggregate value.
+        if (!col.name.empty() && agg_cursor < agg_vals.size()) {
+            out.push_back(agg_vals[agg_cursor++]);
+            continue;
+        }
+        // (D) An empty-named / unmatched column is a group key whose provenance and
+        //     name were rewritten (e.g. by decorrelation, which emits the grouping
+        //     key with an empty name). Fall back to the first unused key, else NULL.
+        for (std::size_t i = 0; i < agg->group_keys.size(); ++i)
+            if (!gk_used[i]) { chosen = static_cast<int>(i); break; }
+        if (chosen >= 0) {
+            gk_used[static_cast<std::size_t>(chosen)] = true;
             out.push_back(gk_vals[static_cast<std::size_t>(chosen)]);
         } else {
             out.push_back(null());

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -134,6 +134,39 @@ static void register_conformance_tests() {
         }
     });
 
+    // ---- Aliased aggregate columns end-to-end. Regression guard for an oracle
+    //   defect the stage suite surfaced: the evaluator identified an aggregate
+    //   output column by matching its name to the aggregate's func_name, so an
+    //   ALIAS (`SUM(x) AS s`) renamed the column, the value was never placed, and
+    //   the column collapsed to NULL - which in turn made any HAVING or ORDER BY
+    //   over an aliased aggregate wrong (HAVING dropped every row; ORDER BY
+    //   returned NULL aggregates). The DB25 plans were correct throughout; only
+    //   the reference evaluator was wrong. These pin the corrected behavior.
+    //   Killed by M4 (aggregate off by one) and M14 (sort reversed).
+    test("conformance.aliased_aggregate_columns", [] {
+        // Bare aliased aggregates.
+        auto s1 = conform("SELECT dept_id, SUM(salary) AS s, COUNT(*) AS c "
+                          "FROM emp GROUP BY dept_id");
+        if (auto r = eval(s1.optimized, data())) {
+            Table want = { {vi(10), vi(390), vi(3)}, {vi(20), vi(270), vi(2)} };
+            check(bag_equal(*r, want), "aliased SUM/COUNT resolve (not NULL)");
+        }
+        // HAVING over an aliased aggregate (repeats the aggregate expression).
+        auto s2 = conform("SELECT dept_id, SUM(salary) AS total FROM emp "
+                          "GROUP BY dept_id HAVING SUM(salary) > 300");
+        if (auto r = eval(s2.optimized, data())) {
+            Table want = { {vi(10), vi(390)} };  // dept 20's 270 is filtered out
+            check(bag_equal(*r, want), "HAVING over aliased aggregate keeps dept 10 only");
+        }
+        // ORDER BY an aliased aggregate (order-sensitive).
+        auto s3 = conform("SELECT dept_id, SUM(salary) AS s FROM emp "
+                          "GROUP BY dept_id ORDER BY s DESC");
+        if (auto r = eval(s3.optimized, data())) {
+            Table want = { {vi(10), vi(390)}, {vi(20), vi(270)} };  // 390 > 270
+            check(seq_equal(*r, want), "ORDER BY aliased aggregate sorts by its value");
+        }
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
## The bug (found by the #17 conformance suite)

The reference evaluator identified an `Aggregate` output column as an aggregate result by matching its name to the aggregate's `func_name`. An **alias renames the column** (`SUM(x) AS s` → name `"s"`), so the `func_name` test failed, the value was never placed, and the column **collapsed to NULL**. Because the differential oracle runs *bound* and *optimized* through the **same** evaluator, both agreed on the wrong answer — so it stayed invisible until the stage-conformance suite pinned an aliased aggregate against ground truth.

Consequences (all silent):
- any **aliased aggregate** read as NULL;
- a **`HAVING`** repeating an aliased aggregate dropped every row (`NULL > 0` is UNKNOWN);
- **`ORDER BY`** an aliased aggregate returned NULLs.

Important: **the DB25 plans were correct throughout** — the binder/optimizer produced the right tree. This was purely an **oracle defect**. (It also retro-corrects the two "binder-level" findings noted in #17: same root cause, and not the product.)

## The fix

`build_aggregate_output_row` no longer relies on the column name to place aggregate values:

- **(A)** `name == next aggregate's func_name` → aggregate (unaliased fast path, unchanged; also covers the decorrelated `LEFT JOIN + Aggregate` the optimizer builds).
- **(B)** matches a group key by provenance / name → group-key passthrough.
- **(C)** **non-empty** name, unmatched → **aliased aggregate**, consumed positionally (shares the cursor with A, so mixed aliased/unaliased aggregates stay in select-list order).
- **(D)** **empty** name / unmatched → group key. Decorrelation emits the grouping key with an *empty name and no provenance*; the name test in (C)/(D) is exactly what stops it from stealing an aggregate value (the subtlety that made the naive fixes regress the correlated-scalar-aggregate differentials).

Residual (documented in-code): a non-column **expression** group key carries no provenance/name and is the one shape this can't disambiguate; the corpus doesn't exercise it.

## Verification

- Added `conformance.aliased_aggregate_columns`: bare aliased `SUM`/`COUNT`, `HAVING` over an aliased aggregate, and `ORDER BY` over an aliased aggregate.
- `db25_harness`: **95 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all falsifiable; every mutant M1–M16 caught.
- The **3000-plan property differential** (which exercises correlated-scalar-aggregate decorrelation) is unaffected — this was the regression guard that drove the (C)/(D) name discriminator.

Test-only change; no production/library code touched.