### PR TITLE
harness: evaluate INTERSECT ALL / EXCEPT ALL; bump lp pin

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -951,6 +951,20 @@ bool eval_node(const LogicalNode* n, EvalCtx& ctx, Table& out) {
                 return false;
             };
             auto push_distinct = [&](const Row& r) { if (!row_in(r, out)) out.push_back(r); };
+            // Remove ONE row of `t` equal to `r` (multiset take); report success.
+            // Used by the ALL variants to consume matched duplicates so the output
+            // multiplicity is min(count_a, count_b) for INTERSECT ALL and
+            // max(0, count_a - count_b) for EXCEPT ALL.
+            auto take_one = [](const Row& r, Table& t) -> bool {
+                for (std::size_t i = 0; i < t.size(); ++i) {
+                    if (t[i].size() != r.size()) continue;
+                    bool same = true;
+                    for (std::size_t k = 0; k < r.size(); ++k)
+                        if (!value_identical(t[i][k], r[k])) { same = false; break; }
+                    if (same) { t.erase(t.begin() + static_cast<std::ptrdiff_t>(i)); return true; }
+                }
+                return false;
+            };
             switch (n->set_op) {
                 case db25::ast::SetOp::UnionAll:
                     out = std::move(a);
@@ -963,9 +977,19 @@ bool eval_node(const LogicalNode* n, EvalCtx& ctx, Table& out) {
                 case db25::ast::SetOp::Intersect:
                     for (const Row& r : a) if (row_in(r, b)) push_distinct(r);
                     return true;
+                case db25::ast::SetOp::IntersectAll: {
+                    Table brem = b;  // consume matches so multiplicity is min(a,b)
+                    for (const Row& r : a) if (take_one(r, brem)) out.push_back(r);
+                    return true;
+                }
                 case db25::ast::SetOp::Except:
                     for (const Row& r : a) if (!row_in(r, b)) push_distinct(r);
                     return true;
+                case db25::ast::SetOp::ExceptAll: {
+                    Table brem = b;  // each b row cancels one a row: max(0, a - b)
+                    for (const Row& r : a) if (!take_one(r, brem)) out.push_back(r);
+                    return true;
+                }
             }
             ctx.ok = false;
             return false;

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -197,6 +197,32 @@ static void register_conformance_tests() {
                   "derived-table self-join stays 3 rows (not a cross product)");
     });
 
+    // ---- INTERSECT ALL / EXCEPT ALL (multiset set operations). Previously the
+    //   binder dropped the ALL keyword for intersect/except, silently collapsing
+    //   them to the de-duplicating forms. Now they carry through to the plan and
+    //   preserve duplicate rows. `WHERE age IS NOT NULL` drops bob, so each side's
+    //   cities are {NYC,NYC,LA,NULL}. Killed by M2 (ignoring the filter changes
+    //   the multiset).
+    test("conformance.intersect_except_all", [] {
+        auto si = conform("SELECT city FROM users WHERE age IS NOT NULL "
+                          "INTERSECT ALL SELECT city FROM users WHERE age IS NOT NULL");
+        check(si.optimized_dump.find("INTERSECT ALL") != std::string::npos,
+              "plan carries INTERSECT ALL (not collapsed to INTERSECT)");
+        if (auto r = eval(si.optimized, data()))
+            check(bag_equal(*r, Table{ {vs("NYC")}, {vs("NYC")}, {vs("LA")}, {null()} }),
+                  "INTERSECT ALL keeps the duplicate NYC -> 4 rows (min multiplicity)");
+
+        // {NYC,NYC,LA,NULL} EXCEPT ALL {NYC} = {NYC,LA,NULL}: one NYC survives,
+        // whereas the de-duplicating EXCEPT would drop every NYC.
+        auto se = conform("SELECT city FROM users WHERE age IS NOT NULL "
+                          "EXCEPT ALL SELECT city FROM users WHERE id = 1");
+        check(se.optimized_dump.find("EXCEPT ALL") != std::string::npos,
+              "plan carries EXCEPT ALL (not collapsed to EXCEPT)");
+        if (auto r = eval(se.optimized, data()))
+            check(bag_equal(*r, Table{ {vs("NYC")}, {vs("LA")}, {null()} }),
+                  "EXCEPT ALL cancels one NYC -> {NYC,LA,NULL} (3 rows)");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the `INTERSECT ALL` / `EXCEPT ALL` cascade (parser #29 → db25-logical-plan #51 → here).

## What

- Bumps `external/db25-logical-plan` to `main` (`167ffa9`), which lowers `INTERSECT ALL` / `EXCEPT ALL` to the new `SetOp` `ALL` variants instead of silently collapsing them to the de-duplicating forms.
- Implements the multiset semantics in the reference evaluator:
  - `INTERSECT ALL` emits each row `min(count_a, count_b)` times;
  - `EXCEPT ALL` emits `max(0, count_a − count_b)` times;
  - both via a `take_one()` that consumes one matching row from a mutable copy of the right input. NULLs compare equal here (set-op semantics), consistent with the existing `Intersect` / `Except` paths.
- Adds `conformance.intersect_except_all`:
  - `INTERSECT ALL` over a filtered `users` keeps the duplicate city → `{NYC,NYC,LA,NULL}` (4 rows, not the de-duplicated 3);
  - `EXCEPT ALL` cancels one duplicate → `{NYC,LA,NULL}`;
  - each asserts the `ALL` survived into the plan dump (stage-artifact check) and is falsifiable via M2.

## Verification

- `db25_harness`: **97 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all falsifiable; every mutant M1–M16 caught.

With this, `INTERSECT ALL` / `EXCEPT ALL` are correct from parse to result — closing P1 trap #1.