### PR TITLE
bump db25-logical-plan pin: DML/CTE completeness + ON CONFLICT

### DIFF
--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -223,6 +223,25 @@ static void register_conformance_tests() {
                   "EXCEPT ALL cancels one NYC -> {NYC,LA,NULL} (3 rows)");
     });
 
+    // ---- CTE column-list rename and LIKE ... ESCAPE, end to end. `WITH t(x)`
+    //   renames the CTE's output so `SELECT x` resolves; ESCAPE makes the
+    //   following pattern character literal. Both previously failed (analyze /
+    //   parse). Killed by M2 (the age>20 / name filter).
+    test("conformance.cte_columnlist_and_escape", [] {
+        auto s1 = conform("WITH t(x) AS (SELECT id FROM users WHERE age > 20) SELECT x FROM t");
+        if (auto r = eval(s1.optimized, data()))
+            check(bag_equal(*r, Table{{vi(1)},{vi(4)},{vi(5)}}),
+                  "CTE column-list rename resolves -> {1,4,5}");
+
+        // 'a%' matches alice; 'a!%' ESCAPE '!' means a-then-literal-% -> no match.
+        auto s2 = conform("SELECT name FROM users WHERE name LIKE 'a%'");
+        if (auto r = eval(s2.optimized, data()))
+            check(bag_equal(*r, Table{{vs("alice")}}), "LIKE 'a%' -> {alice}");
+        auto s3 = conform("SELECT name FROM users WHERE name LIKE 'a!%' ESCAPE '!'");
+        if (auto r = eval(s3.optimized, data()))
+            check(bag_equal(*r, Table{}), "LIKE 'a!%' ESCAPE '!' (literal %) -> empty");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the P2 **Batch A** cascade (parser #30 → analyzer #27 → db25-logical-plan #53 → here).

## What

Advances `external/db25-logical-plan` to `main` (`0be615e`), landing the whole batch end-to-end:

- **`UPDATE … FROM`** / **`DELETE … USING`** — extra relations resolve and join under the target.
- **`INSERT … DEFAULT VALUES`** — one-empty-row Values source.
- **`WITH t(a, b)`** column-list rename.
- **`LIKE … ESCAPE`** — escaped wildcard is literal.
- **`INSERT … ON CONFLICT`** representation (db25-logical-plan #52) rides along in the same pin bump.

## Coverage

`conformance.cte_columnlist_and_escape`: the CTE column-list rename evaluates to `{1,4,5}`; `LIKE 'a!%' ESCAPE '!'` treats `%` literally (empty) vs `LIKE 'a%'` (matches alice). Both falsifiable via M2. (The DML shapes aren't executed by the reference evaluator — they're covered at the plan level by db25-logical-plan `test_binder`.)

## Verification

- `db25_harness`: **98 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all falsifiable; every mutant caught.

Closes P2 Batch A. Next: **Batch B** (expression surface — `::`, `ROW`, `IS TRUE/FALSE/UNKNOWN`, `ILIKE`, aggregate `FILTER`).