### PR TITLE
ci: add umbrella CI (build + falsifiability gate + sanitizers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+# Builds the full native stack (tokenizer -> parser + analyzer -> logical plan ->
+# harness) from the pinned submodules and runs the test suite AND the
+# falsifiability gate. The gate (db25_gate) is the load-bearing check: it fails
+# the build if any test is non-falsifiable (survives every mutant) or if a
+# mutant escapes, so a change that weakens the harness cannot merge silently.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-gate:
+    name: build & gate (${{ matrix.cxx }}, ${{ matrix.build_type }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cxx: g++-13, build_type: Release }
+          - { cxx: g++-14, build_type: Release }
+          - { cxx: g++-14, build_type: Debug }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.cxx }}
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+
+      - name: Build
+        run: cmake --build build -j
+
+      # Runs db25_harness (the suite), db25_gate (the falsifiability gate), and
+      # the logical-plan unit tests brought in via add_subdirectory.
+      - name: Suite + falsifiability gate
+        working-directory: build
+        run: ctest --output-on-failure
+
+  sanitizers:
+    name: ASan + UBSan (g++-14)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14
+
+      - name: Configure (ASan/UBSan)
+        run: >
+          cmake -S . -B build-san
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_COMPILER=g++-14
+          -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      - name: Build
+        run: cmake --build build-san -j
+
+      # Runs the suite + logical-plan unit tests under ASan/UBSan to catch memory
+      # and UB defects. The falsifiability gate is excluded here: it is pure logic
+      # (already enforced by the non-sanitized build-gate jobs) and its mutant x
+      # property-test loop is far too slow to be worth re-running under ASan.
+      - name: Suite under sanitizers (gate excluded)
+        working-directory: build-san
+        run: ctest --output-on-failure -E db25_gate

--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -193,10 +193,20 @@ Value eval_arith(BinaryOp op, const Value& a, const Value& b, EvalCtx& ctx) {
     double da, db;
     if (!numeric_of(a, da) || !numeric_of(b, db)) { ctx.ok = false; return null(); }
     const bool ints = both_int(a, b);
+    // Integer arithmetic that would overflow int64 is not representable, so the
+    // reference returns NULL - consistent with division by zero below, and (via
+    // __builtin_*_overflow) free of the signed-overflow UB a plain `+`/`-`/`*`
+    // would hit on out-of-range operands.
     switch (op) {
-        case BinaryOp::Add: return ints ? vi(std::get<std::int64_t>(a) + std::get<std::int64_t>(b)) : vd(da + db);
-        case BinaryOp::Subtract: return ints ? vi(std::get<std::int64_t>(a) - std::get<std::int64_t>(b)) : vd(da - db);
-        case BinaryOp::Multiply: return ints ? vi(std::get<std::int64_t>(a) * std::get<std::int64_t>(b)) : vd(da * db);
+        case BinaryOp::Add:
+            if (!ints) return vd(da + db);
+            { std::int64_t r; return __builtin_add_overflow(std::get<std::int64_t>(a), std::get<std::int64_t>(b), &r) ? null() : vi(r); }
+        case BinaryOp::Subtract:
+            if (!ints) return vd(da - db);
+            { std::int64_t r; return __builtin_sub_overflow(std::get<std::int64_t>(a), std::get<std::int64_t>(b), &r) ? null() : vi(r); }
+        case BinaryOp::Multiply:
+            if (!ints) return vd(da * db);
+            { std::int64_t r; return __builtin_mul_overflow(std::get<std::int64_t>(a), std::get<std::int64_t>(b), &r) ? null() : vi(r); }
         case BinaryOp::Divide:
             if (db == 0.0) return null();  // reference: division by zero -> NULL
             return ints ? vi(std::get<std::int64_t>(a) / std::get<std::int64_t>(b)) : vd(da / db);


### PR DESCRIPTION
The umbrella repo had **no CI** — so the harness suite and the **falsifiability gate** (the project's core verification) ran only locally, and every umbrella PR (#16–#21) merged unchecked. This adds `.github/workflows/ci.yml`:

- **build-gate** (g++-13/14 × Release/Debug): recursive-checkout the submodule chain, build, and run `ctest` — which runs `db25_harness` (the suite), **`db25_gate`** (the gate: fails if any test is non-falsifiable or a mutant escapes), and the logical-plan unit tests. The gate is now a **required check** on every PR.
- **sanitizers** (ASan + UBSan): build and run the suite. The gate is excluded here — it's pure logic (already covered above) and its mutant × property-test loop is far too slow to re-run under ASan.

## UB fix (surfaced by the new sanitizer job)

Standing up ASan/UBSan immediately caught a real **signed-overflow UB** in the reference evaluator: integer `+` / `-` / `*` on out-of-range operands overflowed `int64` (UB). Now computed via `__builtin_{add,sub,mul}_overflow`, returning **NULL when the result isn't representable** — consistent with the existing division-by-zero → NULL rule.

## Verification

- Dry-ran the exact CI commands locally: build (Release) + `ctest` → 5/5; ASan/UBSan build + suite → **98/98, no runtime errors** (was a hard UBSan abort before the fix).
- Non-sanitized suite 98/98, gate **PASSED**.

This PR triggers the new workflow on itself. A matching `build + ctest` workflow for db25-logical-plan follows separately.