### PR TITLE
bump lp pin to the :: cast shorthand; add stage-artifact conformance

### DIFF
--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -242,6 +242,20 @@ static void register_conformance_tests() {
             check(bag_equal(*r, Table{}), "LIKE 'a!%' ESCAPE '!' (literal %) -> empty");
     });
 
+    // ---- `::` cast shorthand. x::T is CAST(x AS T); it must lower to the same
+    //   Cast and produce the same result. age::BIGINT > 20 keeps {1,4,5} (bob's
+    //   NULL age dropped), identical to the CAST(...) form. Killed by M2 (filter).
+    test("conformance.cast_shorthand", [] {
+        auto s = conform("SELECT id FROM users WHERE age::BIGINT > 20");
+        if (auto r = eval(s.optimized, data()))
+            check(bag_equal(*r, Table{{vi(1)},{vi(4)},{vi(5)}}),
+                  ":: cast in a predicate -> {1,4,5}");
+        auto s2 = conform("SELECT id FROM users WHERE CAST(age AS BIGINT) > 20");
+        auto r1 = eval(s.optimized, data());
+        auto r2 = eval(s2.optimized, data());
+        if (r1 && r2) check(bag_equal(*r1, *r2), "x::T evaluates identically to CAST(x AS T)");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the `::` cast shorthand cascade (parser #31 → parser #32 → db25-logical-plan #54 → here).

## What

- Advances `external/db25-logical-plan` to `main` (`0f8cf89`), which pins parser `b24ec0f` — the **`::` postfix cast shorthand** (`x::T` parses as `CAST(x AS T)`), plus the `ManySmallAllocations` timing-guard CI fix.
- Adds **`conformance.cast_shorthand`** to the stage-artifact suite:
  - `SELECT id FROM users WHERE age::BIGINT > 20` evaluates to `{1,4,5}` through the full pipeline (bob's NULL age dropped), and
  - is asserted **identical** to the `CAST(age AS BIGINT)` form — same lowered Cast, same result.
  - The result anchor keeps the test falsifiable (killed by **M2**, the filter mutant), so the gate accepts it.

## Verification

- `db25_harness`: **99 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 99 tests falsifiable; every mutant caught.

This closes the `::` cast shorthand end-to-end: parse → analyze → bind → optimize → result. Next in P2 Batch B: `ROW`, `IS TRUE/FALSE/UNKNOWN`, `ILIKE`, aggregate `FILTER`.