### PR TITLE
evaluate IS [NOT] TRUE/FALSE/UNKNOWN; add stage-artifact conformance

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -65,6 +65,7 @@ namespace db25::harness {
 
 using db25::plan::Expr;
 using db25::plan::ExprKind;
+using db25::plan::BoolTest;
 using db25::plan::LogicalNode;
 using db25::plan::LogicalNodePtr;
 using db25::plan::LogicalOp;
@@ -455,6 +456,20 @@ Value eval_expr(const Expr* e, const Row& row, EvalCtx& ctx) {
             const Value a = eval_expr(e->children[0].get(), row, ctx);
             const bool isnull = is_null(a);
             return vb(e->negated() ? !isnull : isnull);  // negated == IS NOT NULL
+        }
+        case ExprKind::BooleanTest: {
+            // IS [NOT] TRUE/FALSE/UNKNOWN collapses the operand's 3VL truth value
+            // to a plain 2VL boolean (never NULL). This is exactly what makes
+            // `x IS NOT TRUE` differ from `NOT x`: the former keeps NULL/UNKNOWN
+            // rows, the latter propagates them as UNKNOWN and drops them.
+            const Bool3 b = to_bool3(eval_expr(e->children[0].get(), row, ctx));
+            bool result = false;
+            switch (e->bool_test) {
+                case BoolTest::True:    result = (b == Bool3::True);    break;
+                case BoolTest::False:   result = (b == Bool3::False);   break;
+                case BoolTest::Unknown: result = (b == Bool3::Unknown); break;
+            }
+            return vb(e->negated() ? !result : result);
         }
         case ExprKind::InList: {
             const Value v = eval_expr(e->children[0].get(), row, ctx);

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -256,6 +256,39 @@ static void register_conformance_tests() {
         if (r1 && r2) check(bag_equal(*r1, *r2), "x::T evaluates identically to CAST(x AS T)");
     });
 
+    // ---- IS [NOT] TRUE / FALSE / UNKNOWN. A three-valued boolean test that
+    //   collapses the operand's 3VL truth value to a plain 2VL boolean (never
+    //   NULL). Over users, `age > 20` is TRUE for {1,4,5}, FALSE for {3}, and
+    //   UNKNOWN for {2} (bob's NULL age). Each IS-test selects exactly one
+    //   bucket. The load-bearing distinction: `(age>20) IS NOT TRUE` keeps the
+    //   UNKNOWN row {2} that a plain `NOT (age>20)` drops - that difference is
+    //   the whole reason the feature exists. Killed by M2 (filter ignored ->
+    //   every row passes, so the anchors change).
+    test("conformance.boolean_test", [] {
+        auto s = conform("SELECT id FROM users WHERE (age > 20) IS TRUE");
+        check(ast_has(s, NT::BooleanTestExpr), "AST has BooleanTestExpr");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::Filter), "plan has Filter");
+        if (auto r = eval(s.optimized, data()))
+            check(bag_equal(*r, Table{{vi(1)},{vi(4)},{vi(5)}}),
+                  "(age>20) IS TRUE -> {1,4,5}");
+        if (auto r = eval(conform("SELECT id FROM users WHERE (age > 20) IS FALSE")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(3)}}), "(age>20) IS FALSE -> {3}");
+        if (auto r = eval(conform("SELECT id FROM users WHERE (age > 20) IS UNKNOWN")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(2)}}), "(age>20) IS UNKNOWN -> {2} (NULL age)");
+        // The 3VL distinction: IS NOT TRUE keeps the UNKNOWN row; NOT drops it.
+        auto not_true = eval(conform("SELECT id FROM users WHERE (age > 20) IS NOT TRUE")
+                                 .optimized, data());
+        auto plain_not = eval(conform("SELECT id FROM users WHERE NOT (age > 20)")
+                                  .optimized, data());
+        if (not_true) check(bag_equal(*not_true, Table{{vi(2)},{vi(3)}}),
+                            "(age>20) IS NOT TRUE -> {2,3} (keeps the UNKNOWN row)");
+        if (plain_not) check(bag_equal(*plain_not, Table{{vi(3)}}),
+                             "NOT (age>20) -> {3} (UNKNOWN row dropped)");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the `IS [NOT] TRUE/FALSE/UNKNOWN` boolean-test cascade (parser #33 → analyzer #28 → db25-logical-plan #55 → here).

## What

- Bumps `external/db25-logical-plan` to `main` (`f6fd3b7`), landing the feature end-to-end: parser `BooleanTestExpr` node, analyzer inference, and the `ExprKind::BooleanTest` lowering.
- Implements the **evaluator**: `BooleanTest` collapses the operand's three-valued truth (via `to_bool3`) to a plain 2VL boolean and **never returns NULL**. `IS NOT` negates the result. This is exactly what makes `x IS NOT TRUE` differ from `NOT x` — the former keeps NULL/UNKNOWN rows, the latter propagates them as UNKNOWN and drops them.

## Coverage

Adds `conformance.boolean_test`. Over `users`, `age > 20` is TRUE `{1,4,5}`, FALSE `{3}`, UNKNOWN `{2}` (bob's NULL age). Each IS-test selects one bucket, and the load-bearing anchor pins:

- `(age>20) IS NOT TRUE` → `{2,3}` (keeps the UNKNOWN row) **vs** `NOT (age>20)` → `{3}` (drops it).

Asserts the `BooleanTestExpr` node reaches the AST and the `Filter` operator reaches the plan. Falsifiable via **M2** (filter ignored → every row passes → anchors change).

## Verification

- `db25_harness`: **100 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 100 tests falsifiable; every mutant caught.

This closes `IS [NOT] TRUE/FALSE/UNKNOWN` end-to-end: parse → analyze → bind → optimize → result.