### PR TITLE
evaluate ILIKE (case-insensitive LIKE); add stage-artifact conformance

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -522,8 +522,24 @@ Value eval_expr(const Expr* e, const Row& row, EvalCtx& ctx) {
                 esc = (*es)[0];
                 has_esc = true;
             }
-            bool m = like_match(si->data(), si->data() + si->size(),
-                                pi->data(), pi->data() + pi->size(), esc, has_esc);
+            bool m;
+            if (e->case_insensitive()) {
+                // ILIKE: ASCII-fold both input and pattern (and the escape char)
+                // to lower case, then match. Folding both sides yields
+                // case-insensitive semantics through the same matcher.
+                auto fold = [](char c) {
+                    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+                };
+                std::string ls(*si), lp(*pi);
+                for (char& c : ls) c = fold(c);
+                for (char& c : lp) c = fold(c);
+                const char fesc = has_esc ? fold(esc) : esc;
+                m = like_match(ls.data(), ls.data() + ls.size(),
+                               lp.data(), lp.data() + lp.size(), fesc, has_esc);
+            } else {
+                m = like_match(si->data(), si->data() + si->size(),
+                               pi->data(), pi->data() + pi->size(), esc, has_esc);
+            }
             if (e->negated()) m = !m;
             return vb(m);
         }

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -289,6 +289,28 @@ static void register_conformance_tests() {
                              "NOT (age>20) -> {3} (UNKNOWN row dropped)");
     });
 
+    // ---- ILIKE (case-insensitive LIKE). users.name is lower-case
+    //   (alice/bob/carol/dave/eve). `name ILIKE 'A%'` matches alice
+    //   case-insensitively -> {1}, whereas the case-sensitive `name LIKE 'A%'`
+    //   matches nothing -> {}. That contrast is the whole feature. NOT ILIKE
+    //   inverts to the complement. Killed by M2 (filter ignored -> all rows).
+    test("conformance.ilike", [] {
+        auto s = conform("SELECT id FROM users WHERE name ILIKE 'A%'");
+        check(ast_has(s, NT::LikeExpr), "AST has LikeExpr (ILIKE)");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::Filter), "plan has Filter");
+        if (auto r = eval(s.optimized, data()))
+            check(bag_equal(*r, Table{{vi(1)}}), "name ILIKE 'A%' -> {1} (alice)");
+        // The distinction from case-sensitive LIKE: same pattern, no match.
+        if (auto r = eval(conform("SELECT id FROM users WHERE name LIKE 'A%'")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{}), "name LIKE 'A%' -> {} (case-sensitive)");
+        if (auto r = eval(conform("SELECT id FROM users WHERE name NOT ILIKE 'A%'")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(2)},{vi(3)},{vi(4)},{vi(5)}}),
+                  "name NOT ILIKE 'A%' -> {2,3,4,5}");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the `ILIKE` cascade (parser #34 → db25-logical-plan #56 → here).

## What

- Bumps `external/db25-logical-plan` to `main` (`1e52c0a`), landing `ILIKE` end-to-end: parser `LikeExpr` tagged `ILIKE`, and the `ExprFlagCaseInsensitive` lowering.
- Implements the **evaluator**: when a `Like` carries the case-insensitive flag, the input, the pattern, and the escape character are ASCII-folded to lower case before matching — case-insensitive semantics through the same matcher. NULL propagation and `NOT` inversion are unchanged.

## Coverage

Adds `conformance.ilike`. `users.name` is lower-case, so:

- `name ILIKE 'A%'` → `{1}` (matches alice case-insensitively),
- `name LIKE 'A%'` → `{}` (case-sensitive, no match) — the contrast that is the whole feature,
- `name NOT ILIKE 'A%'` → `{2,3,4,5}`.

Asserts the `LikeExpr` node reaches the AST and the `Filter` operator reaches the plan. Falsifiable via **M2** (filter ignored → every row passes → anchors change).

## Verification

- `db25_harness`: **101 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 101 tests falsifiable; every mutant caught.

Closes `ILIKE` end-to-end: parse → analyze → bind → optimize → result.