### PR TITLE
evaluate aggregate FILTER (WHERE ...); add stage-artifact conformance

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -624,13 +624,25 @@ Value compute_aggregate(const Expr* call, const std::vector<Row>& group_rows, Ev
     const std::string& fn = call->func_name;
     const bool distinct = call->distinct;
 
+    // Aggregate FILTER (WHERE p): only rows for which the predicate is TRUE
+    // contribute to this aggregate. M17 ignores the filter, so a filtered
+    // COUNT(*) wrongly equals the unfiltered COUNT(*).
+    std::vector<Row> filtered;
+    const std::vector<Row>* src = &group_rows;
+    if (call->filter && g_mutant != 17) {
+        for (const Row& r : group_rows)
+            if (is_true(eval_expr(call->filter.get(), r, ctx))) filtered.push_back(r);
+        src = &filtered;
+    }
+    const std::vector<Row>& rows = *src;
+
     if (fn == "COUNT") {
         std::int64_t n = 0;
         if (call->children.empty()) {
-            n = static_cast<std::int64_t>(group_rows.size());  // COUNT(*)
+            n = static_cast<std::int64_t>(rows.size());  // COUNT(*)
         } else {
             std::vector<Value> seen;
-            for (const Row& r : group_rows) {
+            for (const Row& r : rows) {
                 Value v = eval_expr(call->children[0].get(), r, ctx);
                 // M9: count NULL argument rows too, so COUNT(age) wrongly equals
                 // COUNT(*). Caught by the COUNT(nullable) < COUNT(*) test.
@@ -650,7 +662,7 @@ Value compute_aggregate(const Expr* call, const std::vector<Row>& group_rows, Ev
 
     // SUM / AVG / MIN / MAX collect non-null argument values.
     std::vector<Value> vals;
-    for (const Row& r : group_rows) {
+    for (const Row& r : rows) {
         Value v = eval_expr(call->children.empty() ? nullptr : call->children[0].get(), r, ctx);
         if (is_null(v)) continue;
         if (distinct) {
@@ -1365,6 +1377,7 @@ const MutantInfo kMutants[] = {
     {14, "M14 Sort eval reverses the row order (wrong ORDER BY direction)"},
     {15, "M15 COALESCE keeps only its first operand (USING/NATURAL merge loses the right copy)"},
     {16, "M16 outer-join eval drops null-extended rows (LEFT/RIGHT/FULL degrade to inner)"},
+    {17, "M17 aggregate FILTER ignored (filtered aggregate degrades to unfiltered)"},
 };
 }  // namespace
 

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -311,6 +311,31 @@ static void register_conformance_tests() {
                   "name NOT ILIKE 'A%' -> {2,3,4,5}");
     });
 
+    // ---- Aggregate FILTER (WHERE p). Only rows where p is TRUE feed the
+    //   aggregate. orders.amount is {50,5,30,NULL,8,120,40}; amount > 40 is TRUE
+    //   for 2 of the 7 rows (50, 120), so COUNT(*) FILTER (WHERE amount > 40)
+    //   is 2 -- versus 7 unfiltered. SUM(amount) FILTER (WHERE status='paid')
+    //   sums the paid rows {50,5,NULL,8} -> 63 (NULL skipped). Killed by M17
+    //   (filter ignored -> filtered aggregate equals the unfiltered one) and by
+    //   M4 (COUNT/SUM off by one).
+    test("conformance.aggregate_filter", [] {
+        auto s = conform("SELECT COUNT(*) FILTER (WHERE amount > 40) FROM orders");
+        check(ast_has(s, NT::FunctionCall), "AST has the aggregate call");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::Aggregate), "plan has Aggregate");
+        if (auto r = eval(s.optimized, data()))
+            check(bag_equal(*r, Table{{vi(2)}}),
+                  "COUNT(*) FILTER (WHERE amount>40) -> 2");
+        // Contrast with the unfiltered count over the same group.
+        if (auto r = eval(conform("SELECT COUNT(*) FROM orders").optimized, data()))
+            check(bag_equal(*r, Table{{vi(7)}}), "COUNT(*) -> 7 (unfiltered)");
+        // FILTER also restricts SUM; NULL amounts are skipped as usual.
+        if (auto r = eval(conform("SELECT SUM(amount) FILTER (WHERE status = 'paid') "
+                                  "FROM orders").optimized, data()))
+            check(bag_equal(*r, Table{{vi(63)}}),
+                  "SUM(amount) FILTER (WHERE status='paid') -> 63");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the aggregate `FILTER` cascade (parser #35 → analyzer #29 → db25-logical-plan #57 → here).

## What

- Bumps `external/db25-logical-plan` to `main` (`a55b0a1`), landing aggregate `FILTER` end-to-end: parser `WhereClause` child, analyzer predicate resolution, and the `Expr::filter` lowering.
- Implements the **evaluator**: `compute_aggregate` restricts a group's rows to those for which the `FILTER` predicate is TRUE before aggregating (COUNT / SUM / AVG / MIN / MAX and DISTINCT all see the filtered set). Unfiltered aggregates are unchanged.
- Adds **mutant M17** (aggregate FILTER ignored): when active, the filter is not applied, so a filtered aggregate degrades to the unfiltered one — making the FILTER semantics explicitly falsifiable rather than relying only on the generic aggregate mutant M4.

## Coverage

Adds `conformance.aggregate_filter`. Over `orders`:

- `COUNT(*) FILTER (WHERE amount > 40)` → `2` (vs `7` unfiltered),
- `SUM(amount) FILTER (WHERE status = 'paid')` → `63` (NULL amount skipped).

Asserts the aggregate call reaches the AST and the `Aggregate` operator reaches the plan. Killed by **M17** (filter ignored) and **M4** (count/sum off by one); verified M17 is caught precisely — only `aggregate_filter` fails under it, no collateral.

## Verification

- `db25_harness`: **102 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 102 tests falsifiable; every mutant M1–M17 caught.

Closes aggregate `FILTER` end-to-end: parse → analyze → bind → optimize → result.