### PR TITLE
evaluate row comparison; add stage-artifact conformance

### DIFF
--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -245,6 +245,68 @@ Value eval_compare(BinaryOp op, const Value& a, const Value& b) {
     return vb(r);
 }
 
+bool is_row_comparison_op(BinaryOp op) {
+    switch (op) {
+        case BinaryOp::Equal:
+        case BinaryOp::NotEqual:
+        case BinaryOp::LessThan:
+        case BinaryOp::LessEqual:
+        case BinaryOp::GreaterThan:
+        case BinaryOp::GreaterEqual:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Row comparison: (a0,a1,...) <op> (b0,b1,...) under SQL three-valued logic.
+//   =  : TRUE iff every pair is equal; FALSE if any pair is definitely unequal;
+//        UNKNOWN if a NULL pair is reached with no earlier definite inequality.
+//   <> : the negation of =.
+//   ordering (< <= > >=): lexicographic. The first position where the rows
+//        differ decides; a NULL reached before any decisive difference makes the
+//        whole comparison UNKNOWN.
+Value eval_row_compare(BinaryOp op, const Expr* la, const Expr* lb,
+                       const Row& row, EvalCtx& ctx) {
+    if (la->kind != ExprKind::Row || lb->kind != ExprKind::Row ||
+        la->children.size() != lb->children.size() || la->children.empty()) {
+        ctx.ok = false;  // arity mismatch / non-row operand: unsupported shape
+        return null();
+    }
+    // M18: compare only the first component, so (1,2) = (1,9) wrongly holds and
+    // (1,2) < (1,9) wrongly fails. Models a row comparison that ignores all but
+    // the leading column.
+    const std::size_t n = (g_mutant == 18) ? 1 : la->children.size();
+    const bool eq_family = (op == BinaryOp::Equal || op == BinaryOp::NotEqual);
+    bool any_unknown = false;
+    for (std::size_t i = 0; i < n; ++i) {
+        const Value ai = eval_expr(la->children[i].get(), row, ctx);
+        const Value bi = eval_expr(lb->children[i].get(), row, ctx);
+        int cmp = 0;
+        bool unk = false;
+        compare3(ai, bi, cmp, unk);
+        if (eq_family) {
+            if (unk) { any_unknown = true; continue; }
+            if (cmp != 0) return vb(op == BinaryOp::NotEqual);  // definitely unequal
+            // equal at this position -> continue
+        } else {
+            if (unk) return null();      // cannot order past a NULL
+            if (cmp != 0) {
+                // First decisive position: strict inequality fixes the order, and
+                // <= / >= agree with < / > here because the rows are not equal.
+                const bool less = (op == BinaryOp::LessThan || op == BinaryOp::LessEqual);
+                return vb(less ? (cmp < 0) : (cmp > 0));
+            }
+            // equal at this position -> continue
+        }
+    }
+    // All compared positions were equal (eq-family may have seen NULLs).
+    if (op == BinaryOp::Equal)    return any_unknown ? null() : vb(true);
+    if (op == BinaryOp::NotEqual) return any_unknown ? null() : vb(false);
+    // Ordering with all positions equal: < and > are false, <= and >= are true.
+    return vb(op == BinaryOp::LessEqual || op == BinaryOp::GreaterEqual);
+}
+
 // 3VL membership: value IN {elems}. Returns True / False / Unknown.
 Bool3 in_membership(const Value& v, const std::vector<Value>& elems) {
     // IN over an EMPTY set is definitely FALSE - even for a NULL probe - because
@@ -392,6 +454,15 @@ Value eval_expr(const Expr* e, const Row& row, EvalCtx& ctx) {
             return null();
         }
         case ExprKind::BinaryOp: {
+            // Row comparison: (a,...) <op> (b,...). Compare element-wise with
+            // lexicographic 3VL before the scalar path evaluates the Row operands
+            // (a Row has no scalar value).
+            if (is_row_comparison_op(e->bin_op) &&
+                (e->children[0]->kind == ExprKind::Row ||
+                 e->children[1]->kind == ExprKind::Row)) {
+                return eval_row_compare(e->bin_op, e->children[0].get(),
+                                        e->children[1].get(), row, ctx);
+            }
             const Value a = eval_expr(e->children[0].get(), row, ctx);
             // Short-circuit AND/OR under 3VL.
             if (e->bin_op == BinaryOp::And) {
@@ -471,6 +542,13 @@ Value eval_expr(const Expr* e, const Row& row, EvalCtx& ctx) {
             }
             return vb(e->negated() ? !result : result);
         }
+        case ExprKind::Row:
+            // A row/tuple only has meaning inside a row comparison, which is
+            // handled in the BinaryOp case before the operands are evaluated.
+            // A standalone row value (e.g. SELECT (a, b)) has no scalar
+            // representation in this evaluator - an explicit eval boundary.
+            ctx.ok = false;
+            return null();
         case ExprKind::InList: {
             const Value v = eval_expr(e->children[0].get(), row, ctx);
             std::vector<Value> elems;
@@ -1378,6 +1456,7 @@ const MutantInfo kMutants[] = {
     {15, "M15 COALESCE keeps only its first operand (USING/NATURAL merge loses the right copy)"},
     {16, "M16 outer-join eval drops null-extended rows (LEFT/RIGHT/FULL degrade to inner)"},
     {17, "M17 aggregate FILTER ignored (filtered aggregate degrades to unfiltered)"},
+    {18, "M18 row comparison uses only the first component (ignores later columns)"},
 };
 }  // namespace
 

--- a/tests/conformance/conformance.cpp
+++ b/tests/conformance/conformance.cpp
@@ -336,6 +336,39 @@ static void register_conformance_tests() {
                   "SUM(amount) FILTER (WHERE status='paid') -> 63");
     });
 
+    // ---- Row constructors and row comparison. (a, b) and ROW(a, b) build a
+    //   RowConstructor; comparing two rows is element-wise with lexicographic
+    //   3VL semantics. users.city is {NYC,LA,NYC,LA,NULL} for ids {1,2,3,4,5}.
+    //   (city, id) = ('NYC', 3) matches ONLY carol (id 3) -- the id component
+    //   discriminates the two NYC rows, which a first-column-only comparison
+    //   would not (city='NYC' alone matches {1,3}). (city, id) > ('NYC', 1) is
+    //   lexicographic: same city NYC, id must exceed 1 -> {3}; NULL city (eve)
+    //   is UNKNOWN and excluded. Killed by M18 (row comparison collapses to the
+    //   first component) and M2 (filter ignored).
+    test("conformance.row_constructor", [] {
+        auto s = conform("SELECT id FROM users WHERE (city, id) = ('NYC', 3)");
+        check(ast_has(s, NT::RowConstructor), "AST has RowConstructor");
+        check(error_count(s) == 0, "analyzer clean");
+        check(plan_contains(s.bound, LogicalOp::Filter), "plan has Filter");
+        if (auto r = eval(s.optimized, data()))
+            check(bag_equal(*r, Table{{vi(3)}}),
+                  "(city,id)=('NYC',3) -> {3} (id discriminates the two NYC rows)");
+        // The same first column alone matches BOTH NYC rows -- the second
+        // component is what narrows it, proving element-wise comparison.
+        if (auto r = eval(conform("SELECT id FROM users WHERE city = 'NYC'")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(1)},{vi(3)}}), "city='NYC' alone -> {1,3}");
+        // Lexicographic ordering; NULL city (eve) is UNKNOWN and excluded.
+        if (auto r = eval(conform("SELECT id FROM users WHERE (city, id) > ('NYC', 1)")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(3)}}),
+                  "(city,id)>('NYC',1) -> {3} (lexicographic, NULL excluded)");
+        // Explicit ROW(...) keyword form evaluates identically.
+        if (auto r = eval(conform("SELECT id FROM users WHERE ROW(id, age) = ROW(4, 40)")
+                              .optimized, data()))
+            check(bag_equal(*r, Table{{vi(4)}}), "ROW(id,age)=ROW(4,40) -> {4}");
+    });
+
     // ---- FEATURE MANIFEST. One row per supported feature: assert its AST node,
     //   a clean analyze, its LogicalOp (when it maps to one), AND its exact
     //   result. The result anchors keep this test falsifiable (M2/M4/... kill the


### PR DESCRIPTION
Final step of the row-constructor cascade (parser #36 → analyzer #30 → db25-logical-plan #58 → here).

## What

- Bumps `external/db25-logical-plan` to `main` (`5ff04b2`), landing row constructors end-to-end: parser `RowConstructor` node, analyzer inference, and the `ExprKind::Row` lowering.
- Implements the **evaluator**: a comparison whose operand is a `Row` is compared **element-wise under SQL three-valued logic** instead of the scalar path.
  - **Equality**: TRUE iff every pair is equal, FALSE on the first definite inequality, UNKNOWN when a NULL pair is reached with no earlier decisive difference.
  - **Ordering** (`< <= > >=`): lexicographic — the first differing position decides; a NULL reached before any decisive difference makes the whole comparison UNKNOWN.
  - A standalone row value (no comparison) is an explicit eval boundary — the scalar `Value` model has no tuple.
- Adds **mutant M18** (row comparison uses only the first component), so the element-wise / lexicographic semantics are explicitly falsifiable.

## Coverage

Adds `conformance.row_constructor`. Over `users`:

- `(city, id) = ('NYC', 3)` → `{3}` — the `id` component discriminates the two NYC rows, where `city = 'NYC'` alone matches `{1,3}`,
- `(city, id) > ('NYC', 1)` → `{3}` — lexicographic, with the NULL city excluded,
- `ROW(id, age) = ROW(4, 40)` → `{4}`.

Killed by **M18** (first component only) and **M2** (filter ignored); verified M18 is caught precisely — only `row_constructor` fails under it.

## Verification

- `db25_harness`: **103 passed, 0 failed**.
- `db25_gate`: **GATE PASSED** — all 103 tests falsifiable; every mutant M1–M18 caught.

Closes row constructors end-to-end: parse → analyze → bind → optimize → result.