### PR TITLE
ci: float submodules on their main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
 # Builds the full native stack (tokenizer -> parser + analyzer -> logical plan ->
-# harness) from the pinned submodules and runs the test suite AND the
+# harness) from the submodules floated to their current main (the committed
+# gitlinks stay pinned for reproducible local / release builds) and runs the
+# test suite AND the
 # falsifiability gate. The gate (db25_gate) is the load-bearing check: it fails
 # the build if any test is non-falsifiable (survives every mutant) or if a
 # mutant escapes, so a change that weakens the harness cannot merge silently.
@@ -25,6 +27,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Float submodules on main
+        # The committed gitlinks stay pinned (reproducible local / release builds),
+        # but CI exercises the suite + integration test against the CURRENT main of
+        # every component, so a parser / analyzer / logical-plan change is validated
+        # end to end without waiting for a pin bump - cross-repo drift surfaces here.
+        run: |
+          set -e
+          git submodule update --init --recursive
+          float() {
+            git -C "$1" fetch --quiet --depth=1 origin main
+            git -C "$1" checkout --quiet FETCH_HEAD
+            echo "floated $1 -> $(git -C "$1" rev-parse --short HEAD)"
+          }
+          float external/db25-logical-plan
+          git -C external/db25-logical-plan submodule update --init --recursive
+          float external/db25-logical-plan/external/parser
+          float external/db25-logical-plan/external/analyzer
 
       - name: Install compiler
         run: |
@@ -53,6 +73,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Float submodules on main
+        # The committed gitlinks stay pinned (reproducible local / release builds),
+        # but CI exercises the suite + integration test against the CURRENT main of
+        # every component, so a parser / analyzer / logical-plan change is validated
+        # end to end without waiting for a pin bump - cross-repo drift surfaces here.
+        run: |
+          set -e
+          git submodule update --init --recursive
+          float() {
+            git -C "$1" fetch --quiet --depth=1 origin main
+            git -C "$1" checkout --quiet FETCH_HEAD
+            echo "floated $1 -> $(git -C "$1" rev-parse --short HEAD)"
+          }
+          float external/db25-logical-plan
+          git -C external/db25-logical-plan submodule update --init --recursive
+          float external/db25-logical-plan/external/parser
+          float external/db25-logical-plan/external/analyzer
 
       - name: Install compiler
         run: |


### PR DESCRIPTION
## Summary

Umbrella CI checked out the submodules at their committed gitlinks, so a change merged into **parser / analyzer / logical-plan** was not exercised by the suite or the full-stack integration test until someone bumped the pin. This adds a **"Float submodules on main"** step (after checkout, both CI jobs) that sets every component — `external/db25-logical-plan` and, nested, its `external/parser` + `external/analyzer` — to the current tip of its `main`.

Result: on every umbrella PR and merge, the whole frontend — the **falsifiability gate** and **`db25_integration`** included — is built and tested against the **latest main of every repo**, so cross-repo drift surfaces immediately instead of at the next pin bump.

## Reproducibility preserved

The **committed gitlinks stay pinned** — only CI floats — so local and release builds remain reproducible from the recorded SHAs.

## Safety

Today the floated tips (`logical-plan 6973b3d`, `parser 2b05694`, `analyzer 5233e5d`) are identical to the current pins, so this lands green (that exact combination is already verified 6/6, gate + ASan/UBSan clean). The float mechanism was dry-run against the real component repos.

## Trade-off (intentional)

A green umbrella `main` can later go red on a *re-run* with no umbrella change if a component's `main` breaks — that's the point of floating: it makes the umbrella an early cross-repo integration signal. Each component's own CI still gates its own merges.