### PR TITLE
docs: sync tutorial Level 3 result with the reference evaluator

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -240,19 +240,19 @@ Project (#0:Text, #1:BigInt)                     Project (#0:Text, #1:BigInt)
 ```
 
 The plan is exactly right: three groups (`NYC`, `LA`, and one for the NULL city),
-with a `COUNT(*)` per group; the correct answer is `NYC → 2, LA → 2, NULL → 1`.
+with a `COUNT(*)` per group. The reference evaluator groups the rows (NULL is its
+own group, `NULL == NULL` for grouping) and computes the per-group count:
 
-> **A note on the result here.** DB25 has no executor yet, and the bundled reference
-> evaluator computes group **keys** but does not yet compute grouped aggregate
-> **values**, so it prints the count column as `NULL`:
-> ```
-> 'NYC' | NULL      ← should be 2
-> 'LA'  | NULL      ← should be 2
-> NULL  | NULL      ← should be 1
-> ```
-> The **logical plan is the deliverable** at this stage of the project; the
-> evaluator is a partial stand-in (§7). Scalar aggregates *do* evaluate — see the
-> `COUNT(*)` inside Level 5.
+```
+'NYC' | 2
+'LA'  | 2
+NULL  | 1
+(3 rows)
+```
+
+The **logical plan is the deliverable** at this stage of the project; the evaluator
+is a test stand-in (§7) that nonetheless computes grouped-aggregate values, so the
+counts above are real, not placeholders.
 
 ### Level 4 — Join + predicate pushdown (with a hex literal)
 
@@ -379,10 +379,8 @@ stand-in for the executor DB25 does not have yet, and it is intentionally partia
 - It returns `std::nullopt` for a plan shape it does not implement (a first-class,
   non-crashing "unsupported" outcome), so a differential test skips rather than lies.
 - It implements scans, filters, projects, joins, sorts, limits, DISTINCT, scalar
-  aggregates, and correlated subqueries (nested-loop semantics) with correct
-  three-valued logic.
-- It does **not** yet compute grouped-aggregate values (Level 3), which is why that
-  query's count column shows `NULL`.
+  and grouped aggregates (`GROUP BY`, including a NULL group), and correlated
+  subqueries (nested-loop semantics) with correct three-valued logic.
 
 None of this reflects a gap in the **engine** — the engine's job today ends at the
 optimized logical plan, and those plans are correct. The evaluator is a testing


### PR DESCRIPTION
## Summary

While verifying that the umbrella `examples/` and `docs/tutorial.md` still work end to end, I found the tutorial had drifted out of sync with the reference evaluator. This PR brings the docs back in line with what the runnable programs actually produce.

## Verification performed

Initialized submodules (logical-plan → analyzer → parser → tokenizer), configured and built with CMake / g++ 13.3, and ran everything:

| Item | Result |
|------|--------|
| `db25_tour` | ✅ all 5 levels produce correct plans + results |
| `db25_dialect_features` | ✅ all 6 dialect features `[OK]`, combined statement binds |
| `db25_harness` | ✅ 103 passed, 0 failed |
| `db25_gate` (falsifiability) | ✅ GATE PASSED — all 103 tests falsifiable |

The example programs and their build instructions work exactly as documented.

## The fix

The tutorial states "every plan and result shown here is produced by the runnable programs — nothing is hand-waved," but **Level 3 (GROUP BY) had drifted:**

- **Tutorial claimed:** the evaluator computes group *keys* but not grouped-aggregate *values*, so the `COUNT(*)` column prints as `NULL` (`NYC|NULL, LA|NULL, NULL|NULL`).
- **Reality:** the harness now fully computes grouped aggregates — `db25_tour` prints `NYC|2, LA|2, NULL|1`, and the `smoke.group_by_counts` test passes.

Changes to `docs/tutorial.md`:
- Replaced the Level 3 "note on the result" placeholder block with the real evaluated result (`NYC|2, LA|2, NULL|1`).
- Updated the §7 evaluator-capabilities list to state that scalar **and grouped** aggregates (including a NULL group) are computed, removing the stale "does not yet compute grouped-aggregate values" bullet.

Docs-only change; no code or build behavior affected.
